### PR TITLE
Add an `accumulate` keyword to `AbstractSequentialSystem.raytrace()`

### DIFF
--- a/optika/propagators.py
+++ b/optika/propagators.py
@@ -28,9 +28,9 @@ def propagate_rays(
     Parameters
     ----------
     propagators
-        a sequence of ray propagators to interact with ``rays``
+        A sequence of ray propagators to interact with `rays`.
     rays
-        the input rays to propagate through the sequence
+        The input rays to propagate through the sequence.
     """
     if isinstance(propagators, AbstractRayPropagator):
         propagators = [propagators]
@@ -54,11 +54,11 @@ def accumulate_rays(
     Parameters
     ----------
     propagators
-        a sequence of ray propagators to interact with ``rays``
+        A sequence of ray propagators to interact with `rays`.
     rays
-        the input rays to propagate through the sequence
+        The input rays to propagate through the sequence.
     axis
-        the new axis representing the sequence of propagators
+        The new logical axis representing the sequence of propagators.
     """
     if isinstance(propagators, AbstractRayPropagator):
         propagators = [propagators]
@@ -98,7 +98,7 @@ class AbstractRayPropagator(
         Parameters
         ----------
         rays
-            a set of input rays that will interact with this object
+            A set of input rays that will interact with this object.
         """
 
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -549,11 +549,12 @@ class AbstractSequentialSystem(
         axis: None | str = None,
         normalized_field: bool = True,
         normalized_pupil: bool = True,
+        accumulate: bool = True,
     ) -> optika.rays.RayFunctionArray:
         """
         Given the wavelength, field position, and pupil position of some input
         rays, trace those rays through the system and return the result in
-        global coordinates, including all intermediate rays.
+        global coordinates, optionally including all intermediate rays.
 
         Parameters
         ----------
@@ -580,6 +581,8 @@ class AbstractSequentialSystem(
         normalized_pupil
             A boolean flag indicating whether the `pupil` parameter is given
             in normalized or physical units.
+        accumulate
+            Whether to include intermediate rays in the result.
 
         See Also
         --------
@@ -614,11 +617,18 @@ class AbstractSequentialSystem(
 
         surfaces = self.surfaces_all
 
-        result.outputs = optika.propagators.accumulate_rays(
-            propagators=surfaces,
-            rays=rays,
-            axis=axis,
-        )
+        if accumulate:
+            result.outputs = optika.propagators.accumulate_rays(
+                propagators=surfaces,
+                rays=rays,
+                axis=axis,
+            )
+        else:
+            result.outputs = optika.propagators.propagate_rays(
+                propagators=surfaces,
+                rays=rays,
+            )
+
         return result
 
     def rayfunction(
@@ -633,7 +643,7 @@ class AbstractSequentialSystem(
         """
         Given the wavelength, field position, and pupil position of some input
         rays, trace those rays through the system and return the resulting
-        rays in local coordinates at the last surface.
+        rays in local coordinates of the sensor (if it exists).
 
         Parameters
         ----------
@@ -660,7 +670,7 @@ class AbstractSequentialSystem(
 
         See Also
         --------
-        raytrace : Similar to `rayfunction` except it computes all the
+        raytrace : Similar to `rayfunction` except it can compute all the
             intermediate rays, and it returns results in global coordinates.
         """
 

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -118,22 +118,26 @@ class AbstractTestAbstractSequentialSystem(
             ),
         ],
     )
+    @pytest.mark.parametrize("accumulate", [True, False])
     def test_raytrace(
         self,
         a: optika.systems.AbstractSequentialSystem,
         wavelength: None | u.Quantity | na.AbstractScalar,
         field: None | na.AbstractCartesian2dVectorArray,
         pupil: None | na.AbstractCartesian2dVectorArray,
+        accumulate: bool,
     ):
         raytrace = a.raytrace(
             wavelength=wavelength,
             field=field,
             pupil=pupil,
+            accumulate=accumulate,
         )
         assert isinstance(raytrace, optika.rays.RayFunctionArray)
         assert isinstance(raytrace.inputs, optika.vectors.ObjectVectorArray)
         assert isinstance(raytrace.outputs, optika.rays.RayVectorArray)
-        assert a.axis_surface in raytrace.shape
+        if accumulate:
+            assert a.axis_surface in raytrace.shape
 
     @pytest.mark.parametrize(
         argnames="wavelength,field,pupil",


### PR DESCRIPTION
## Summary

Adds an `accumulate` keyword argument to `AbstractSequentialSystem.raytrace()`.

- `accumulate=True` (default, preserving existing behavior) returns the rays at **every** surface via `optika.propagators.accumulate_rays()`, including the per-surface axis.
- `accumulate=False` returns only the rays at the **final** surface via `optika.propagators.propagate_rays()`, avoiding the per-surface axis when intermediate rays aren't needed.

Also tidies the docstrings of `optika.propagators.propagate_rays()`, `accumulate_rays()`, and `AbstractRayPropagator.propagate_rays()` (capitalization / inline-literal style).

## Testing

`test_raytrace` is parametrized over `accumulate` (`True`/`False`); the `axis_surface` assertion only applies when `accumulate=True`.

```
pytest optika/systems/_sequential_test.py -k test_raytrace   # 16 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)