### PR TITLE
Add `integrate` option and single-cell pupil default to `image()`

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -795,13 +795,12 @@ class AbstractSequentialSystem(
     def image(
         self,
         scene: na.FunctionArray[na.SpectralPositionalVectorArray, na.AbstractScalar],
-        wavelength: None | na.AbstractScalar = None,
         pupil: None | na.AbstractCartesian2dVectorArray = None,
         axis_wavelength: None | str = None,
         axis_field: None | tuple[str, str] = None,
         axis_pupil: None | tuple[str, str] = None,
+        integrate: bool = True,
         noise: bool = True,
-        **kwargs,
     ) -> na.FunctionArray[na.SpectralPositionalVectorArray, na.AbstractScalar]:
         """
         Forward model of the optical system.
@@ -813,47 +812,50 @@ class AbstractSequentialSystem(
             The spectral radiance of the scene as a function of wavelength
             and field position.
             The inputs must be cell vertices.
-        wavelength
-            The vertices of the final wavelength grid on the image plane.
-            If :obj:`None` (the default), ``scene.inputs.wavelength`` is used.
         pupil
             The vertices of the pupil grid in either normalized or physical
             coordinates.
-            If :obj:`None`, ``self.grid_input.pupil`` is used.
+            If :obj:`None` (the default), the pupil grid will only have one cell.
         axis_wavelength
-            The logical axis corresponding to changing wavelength coordinate.
+            The logical axis of `scene` corresponding to changing wavelength coordinate.
             If :obj:`None`,
             ``set(scene.inputs.wavelength.shape) - set(self.shape)``,
             should have only one element.
         axis_field
-            The two logical axes corresponding to changing field coordinate.
+            The two logical axes of `scene` corresponding to changing field coordinate.
             If :obj:`None`,
             ``set(scene.inputs.position.shape) - set(self.shape) - {axis_wavelength}``,
             should have exactly two elements.
         axis_pupil
-            The two logical axes corresponding to changing pupil coordinate.
+            The two logical axes of `pupil` corresponding to changing pupil coordinate.
             If :obj:`None`,
             ``set(pupil.shape) - set(self.shape) - {axis_wavelength,} - set(axis_field)``,
             should have exactly two elements.
+            If `pupil` is :obj:`None`, this parameter is ignored.
+        integrate
+            Whether to integrate the wavelength axis.
+            Real images usually have the wavelength axis integrated since they use
+            a black/white sensor, but it can be useful to leave the wavelengths
+            separate for introspective purposes.
         noise
             Whether to add noise to the result.
-        kwargs
-            Additional keyword arguments used by subclass implementations
-            of this method.
         """
 
         shape = self.shape
 
         scene = scene.explicit
 
-        wavelength_scene = scene.inputs.wavelength
+        wavelength = scene.inputs.wavelength
         field = scene.inputs.position
 
-        if wavelength is None:
-            wavelength = wavelength_scene
-
         if pupil is None:
-            pupil = self.grid_input.pupil
+            axis_pupil = ("_pupil_x", "_pupil_y")
+            pupil = na.Cartesian2dVectorLinearSpace(
+                start=-1,
+                stop=1,
+                axis=na.Cartesian2dVectorArray(*axis_pupil),
+                num=2,
+            )
 
         unit_field = na.unit_normalized(field)
         unit_pupil = na.unit_normalized(pupil)
@@ -862,7 +864,7 @@ class AbstractSequentialSystem(
         normalized_pupil = unit_pupil.is_equivalent(u.dimensionless_unscaled)
 
         if axis_wavelength is None:
-            axis_wavelength = set(wavelength_scene.shape) - set(shape)
+            axis_wavelength = set(wavelength.shape) - set(shape)
             axis_wavelength = tuple(axis_wavelength)
             if len(axis_wavelength) != 1:  # pragma: nocover
                 raise ValueError(
@@ -894,7 +896,7 @@ class AbstractSequentialSystem(
 
         rayfunction = self._rayfunction_from_vertices(
             radiance=scene.outputs,
-            wavelength=wavelength_scene,
+            wavelength=wavelength,
             field=field,
             pupil=pupil,
             axis_wavelength=axis_wavelength,
@@ -903,6 +905,15 @@ class AbstractSequentialSystem(
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
         )
+
+        if integrate:
+            wavelength = na.stack(
+                arrays=[
+                    wavelength.min(axis_wavelength),
+                    wavelength.max(axis_wavelength),
+                ],
+                axis=axis_wavelength,
+            )
 
         return self.sensor.readout(
             rays=rayfunction.outputs,

--- a/optika/systems/_systems_test.py
+++ b/optika/systems/_systems_test.py
@@ -22,7 +22,7 @@ class AbstractTestAbstractSystem(
                         start=530 * u.nm,
                         stop=531 * u.nm,
                         axis="wavelength",
-                        num=2,
+                        num=3,
                     ),
                     position=na.Cartesian2dVectorLinearSpace(
                         start=-1,
@@ -39,15 +39,41 @@ class AbstractTestAbstractSystem(
             )
         ],
     )
+    @pytest.mark.parametrize(
+        argnames="pupil",
+        argvalues=[
+            None,
+            na.Cartesian2dVectorLinearSpace(
+                start=-1,
+                stop=+1,
+                axis=na.Cartesian2dVectorArray("pupil_x", "pupil_y"),
+                num=3,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        argnames="integrate",
+        argvalues=[False, True],
+    )
     def test_image(
         self,
         a: optika.systems.AbstractSystem,
         scene: na.FunctionArray[na.SpectralPositionalVectorArray, na.AbstractScalar],
+        pupil: None | na.AbstractCartesian2dVectorArray,
+        integrate: bool,
     ):
-        result = a.image(scene)
+        result = a.image(scene, pupil=pupil, integrate=integrate)
         assert isinstance(result, na.FunctionArray)
         assert isinstance(result.inputs, na.SpectralPositionalVectorArray)
         assert isinstance(result.outputs, na.AbstractScalar)
         assert np.all(result.inputs.wavelength > 0 * u.nm)
         assert na.unit_normalized(result.inputs.position).is_equivalent(u.mm)
         assert result.outputs.sum() != (0 * u.electron)
+
+        num_wavelength = scene.inputs.wavelength.shape["wavelength"]
+        if integrate:
+            # the wavelength axis is collapsed into a single bin (min/max edges)
+            assert result.inputs.wavelength.shape["wavelength"] == 2
+        else:
+            # the scene's wavelength grid is preserved
+            assert result.inputs.wavelength.shape["wavelength"] == num_wavelength


### PR DESCRIPTION
## Summary

Reworks `AbstractSequentialSystem.image()` in `optika/systems/_sequential.py`:

- **Replaces the `wavelength` parameter with an `integrate: bool = True` flag.** When `integrate=True` the wavelength axis is collapsed into a single bin spanning `[min, max]` of the scene wavelengths (the usual case for a black/white sensor). Setting `integrate=False` retains the per-wavelength image for introspection.
- **`pupil` now defaults to a single normalized cell** (`[-1, 1]²`) when not supplied, instead of `self.grid_input.pupil`.
- **Drops the unused `**kwargs`** from the signature.

## Tests

Extends `test_image` with parametrizations over `integrate` (`False`/`True`) and `pupil` (`None` / explicit grid) so both new code paths are exercised, and asserts the resulting wavelength bin-edge count (2 when integrating, `num_wavelength` otherwise).

All system tests pass (`152 passed`); `black` and `ruff check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)