### PR TITLE
Sample the radial arms of `CircularSectorAperture.wire`

### DIFF
--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -504,29 +504,47 @@ class CircularSectorAperture(
     def wire(self, num: None | int = None) -> na.Cartesian3dVectorArray:
         if num is None:
             num = self.samples_wire
-        az = na.linspace(
-            start=self.angle_start,
-            stop=self.angle_stop,
-            axis="wire",
-            num=num - 2,
-        )
-        unit_radius = na.unit(self.radius)
-        result = na.Cartesian3dVectorArray(
-            x=self.radius * np.cos(az),
-            y=self.radius * np.sin(az),
-            z=0 * unit_radius if unit_radius is not None else 0,
-        )
 
-        vertex = na.Cartesian3dVectorArray().add_axes("wire")
-        vertex = vertex * unit_radius if unit_radius is not None else vertex
-        result = np.concatenate(
-            [
-                vertex,
-                result,
-                vertex,
-            ],
-            axis="wire",
-        )
+        unit_radius = na.unit(self.radius)
+        z = 0 * unit_radius if unit_radius is not None else 0
+
+        # The boundary of a circular sector has three segments: the two straight
+        # radial arms (from the vertex out to the arc) and the arc itself.
+        # Distribute the points evenly across all three segments -- like the
+        # polygonal apertures -- so the entire boundary is sampled.  Sampling
+        # only the arc would leave the radial arms unsampled.
+        num_segments = 3
+        num_per_segment = num / num_segments
+        segments = []
+        num_cumulative = 0
+        for s in range(num_segments):
+            num_s = int((s + 1) * num_per_segment - num_cumulative)
+            num_cumulative += num_s
+            t = na.linspace(
+                start=0,
+                stop=1,
+                axis="wire",
+                num=num_s,
+                endpoint=num_cumulative == num,
+            )
+            if s == 0:  # radial arm from the vertex out to the start of the arc
+                radius = self.radius * t
+                angle = self.angle_start
+            elif s == 1:  # the arc, from angle_start to angle_stop
+                radius = self.radius
+                angle = self.angle_start + (self.angle_stop - self.angle_start) * t
+            else:  # radial arm from the end of the arc back to the vertex
+                radius = self.radius * (1 - t)
+                angle = self.angle_stop
+            segments.append(
+                na.Cartesian3dVectorArray(
+                    x=radius * np.cos(angle),
+                    y=radius * np.sin(angle),
+                    z=z,
+                )
+            )
+
+        result = na.concatenate(segments, axis="wire")
         if self.transformation is not None:
             result = self.transformation(result)
         return result

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -178,6 +178,20 @@ class TestCircularSectorAperture(
         assert np.all(a.radius >= 0)
 
 
+def test_circular_sector_wire_samples_radial_arms():
+    # The sector boundary has two straight radial arms in addition to the arc;
+    # the wire must sample them, not just the arc.
+    aperture = optika.apertures.CircularSectorAperture(
+        radius=125 * u.mm,
+        angle_start=90 * u.deg,
+        angle_stop=180 * u.deg,
+    )
+    wire = aperture.wire(num=21)
+    radius = np.sqrt(wire.x**2 + wire.y**2)
+    on_arm = (radius > 1 * u.mm) & (radius < (125 * u.mm - 1 * u.mm))
+    assert np.any(on_arm)
+
+
 class AbstractTestAbstractPolygonalAperture(
     AbstractTestAbstractAperture,
 ):


### PR DESCRIPTION
## Summary

`CircularSectorAperture.wire()` built the boundary as `[vertex, arc, vertex]` — it
sampled only the arc and **skipped the two straight radial edges entirely**. A ray
grazing the middle of a radial arm (e.g. `(0, 60 mm)` for a 90°–180° sector) was never
traced. This is inconsistent with the polygonal apertures, whose `wire()` distributes
points along every boundary segment.

This matters anywhere a sector is used as a stop (vignetting, pupil sampling, field-of-view
extent): the aperture boundary was under-sampled.

## Fix

Distribute the `num` points evenly across all three boundary segments — the two radial
arms (vertex ↔ arc) and the arc — so the full sector boundary is sampled. The total point
count is unchanged.

`wire(num=12)` on a 90°–180°, r=125 mm sector:

| | before | after |
|---|---|---|
| points on the arc | 10 | 5 |
| points on the radial arms | **0** | 5 |
| points at the vertex | 2 | 2 |

After the fix, `idx 1 = (0, 31.25)` — partway up a radial arm — as expected.

## Test

Adds `test_circular_sector_wire_samples_radial_arms`; the full
`optika/apertures/_apertures_test.py` passes (20484 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)