### PR TITLE
Add a multinomial fast path to the charge-diffusion sampler

### DIFF
--- a/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020.py
+++ b/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020.py
@@ -750,6 +750,7 @@ def _electrons_measured_quantity(
         energy_pair_inf=energy_pair_inf.reshape(-1, num_x, num_y),
         fano_inf=fano_inf.reshape(-1, num_x, num_y),
         wrap=wrap,
+        factor_multinomial=_factor_multinomial,
     )
 
     result = result.reshape(shape)
@@ -757,6 +758,184 @@ def _electrons_measured_quantity(
     result = result << u.electron
 
     return result
+
+
+_factor_multinomial = 0.25
+"""
+The multinomial path in :func:`_diffuse_electrons` is used when the electron
+count exceeds this factor times the number of cells in the offset window.
+Both paths sample the same distribution; this only selects whichever is
+faster. Larger values favor the per-electron path, :obj:`math.inf` forces it,
+and ``0`` forces the multinomial path.
+"""
+
+_num_sigma_window = 6.0
+"""
+Half-width, in standard deviations, of the bounded offset window used by the
+multinomial path of :func:`_diffuse_electrons`. Probability mass beyond the
+window (~1e-9) is folded into the edge bins, so the total is still conserved
+exactly.
+"""
+
+_sqrt2 = math.sqrt(2.0)
+
+
+@numba.njit(cache=True, inline="always")
+def _normal_cdf(  # pragma: nocover
+    edge: float,
+    origin: float,
+    scale: float,
+) -> float:
+    """Gaussian CDF at `edge` for mean `origin`, where ``scale = 1/(sigma*sqrt2)``."""
+    return 0.5 * (1.0 + math.erf((edge - origin) * scale))
+
+
+@numba.njit(cache=True)
+def _diffuse_electrons(  # pragma: nocover
+    result: np.ndarray,
+    i: int,
+    x: int,
+    y: int,
+    m: int,
+    u: float,
+    v: float,
+    sigma_x: float,
+    sigma_y: float,
+    num_x: int,
+    num_y: int,
+    wrap: bool,
+    factor_multinomial: float,
+) -> None:
+    """
+    Diffuse `m` electrons originating in pixel ``(x, y)`` of image
+    ``result[i]`` and deposit the (integer) counts in place.
+
+    Each electron lands in exactly one pixel, at an integer offset distributed
+    as ``round(gauss(u, sigma_x)), round(gauss(v, sigma_y))``, so the counts
+    are marginally multinomial and the total charge is conserved exactly
+    (up to electrons diffusing off the sensor when `wrap` is :obj:`False`).
+
+    For small `m` the offsets are sampled per electron. For large `m` the
+    electrons are partitioned across a bounded window of integer offsets via
+    conditional binomials, with per-bin probabilities given by the Gaussian
+    integrated over each pixel (an :func:`math.erf` difference). The two paths
+    sample the same distribution, but for photons that liberate many electrons
+    the partition costs ``O(window)`` rather than ``O(m)``.
+
+    Parameters
+    ----------
+    result
+        The output image stack, indexed ``result[i, x, y]``. Modified in place.
+    i
+        Index of the image within the stack.
+    x, y
+        The pixel the electrons originate from.
+    m
+        The number of electrons to diffuse.
+    u, v
+        The sub-pixel origin of the electrons within pixel ``(x, y)``, each in
+        ``[-0.5, 0.5]``. Shared by all `m` electrons of one photon.
+    sigma_x, sigma_y
+        The standard deviation of the diffusion kernel along each axis,
+        in pixels.
+    num_x, num_y
+        The shape of the image.
+    wrap
+        Whether charge diffusing off the sensor re-enters the opposite edge.
+        If :obj:`False`, it is lost.
+    factor_multinomial
+        See :obj:`_factor_multinomial`.
+    """
+
+    if m <= 0:
+        return
+
+    half_x = int(math.ceil(_num_sigma_window * sigma_x)) + 1
+    half_y = int(math.ceil(_num_sigma_window * sigma_y)) + 1
+    num_window_x = 2 * half_x + 1
+    num_window_y = 2 * half_y + 1
+
+    # For few electrons, per-electron sampling is cheaper than partitioning
+    # the window.
+    if m < factor_multinomial * num_window_x * num_window_y:
+        for _ in range(m):
+            p = round(random.gauss(u, sigma_x))
+            q = round(random.gauss(v, sigma_y))
+            x_e = x + p
+            y_e = y + q
+            if wrap:
+                result[i, x_e % num_x, y_e % num_y] += 1
+            elif (0 <= x_e < num_x) and (0 <= y_e < num_y):
+                result[i, x_e, y_e] += 1
+        return
+
+    # Many electrons: partition them across x offsets, then partition each
+    # occupied column across y offsets, via conditional binomials. This
+    # samples the multinomial distribution with product probabilities
+    # P_x(k_x) * P_y(k_y), renormalized over the bounded window.
+    scale_x = 1.0 / (sigma_x * _sqrt2)
+    scale_y = 1.0 / (sigma_y * _sqrt2)
+
+    rem_x = m
+    c_hi_x = _normal_cdf(half_x + 0.5, u, scale_x)
+    c_left = _normal_cdf(-half_x - 0.5, u, scale_x)
+    for kx in range(-half_x, half_x + 1):
+        if rem_x == 0:
+            break
+        c_right = _normal_cdf(kx + 0.5, u, scale_x)
+        denom_x = c_hi_x - c_left
+        if denom_x <= 0.0:
+            n_kx = rem_x
+        else:
+            pc_x = (c_right - c_left) / denom_x
+            if pc_x >= 1.0:
+                n_kx = rem_x
+            elif pc_x <= 0.0:
+                n_kx = 0
+            else:
+                n_kx = np.random.binomial(rem_x, pc_x)
+        c_left = c_right
+        rem_x -= n_kx
+        if n_kx == 0:
+            continue
+
+        x_e = x + kx
+        if wrap:
+            ix = x_e % num_x
+        elif 0 <= x_e < num_x:
+            ix = x_e
+        else:
+            # the whole column diffused off the sensor and is lost
+            continue
+
+        rem_y = n_kx
+        c_hi_y = _normal_cdf(half_y + 0.5, v, scale_y)
+        cy_left = _normal_cdf(-half_y - 0.5, v, scale_y)
+        for ky in range(-half_y, half_y + 1):
+            if rem_y == 0:
+                break
+            cy_right = _normal_cdf(ky + 0.5, v, scale_y)
+            denom_y = c_hi_y - cy_left
+            if denom_y <= 0.0:
+                n_ky = rem_y
+            else:
+                pc_y = (cy_right - cy_left) / denom_y
+                if pc_y >= 1.0:
+                    n_ky = rem_y
+                elif pc_y <= 0.0:
+                    n_ky = 0
+                else:
+                    n_ky = np.random.binomial(rem_y, pc_y)
+            cy_left = cy_right
+            rem_y -= n_ky
+            if n_ky == 0:
+                continue
+
+            y_e = y + ky
+            if wrap:
+                result[i, ix, y_e % num_y] += n_ky
+            elif 0 <= y_e < num_y:
+                result[i, ix, y_e] += n_ky
 
 
 @numba.njit(
@@ -779,6 +958,7 @@ def _electrons_measured_numba(  # pragma: nocover
     energy_pair_inf: np.ndarray,
     fano_inf: np.ndarray,
     wrap: bool,
+    factor_multinomial: float,
 ) -> np.ndarray:
 
     num_i, num_x, num_y, num_n = p_n.shape
@@ -850,27 +1030,26 @@ def _electrons_measured_numba(  # pragma: nocover
                     u = random.uniform(-0.5, 0.5)
                     v = random.uniform(-0.5, 0.5)
 
-                    for e in range(m_ij):
-                        if z_ij < z_ff and wp_x > 0 and wp_y > 0:
-                            w = z_ff * math.sqrt(1 - z_ij / z_ff)
-
-                            p = random.gauss(u, w / wp_x)
-                            q = random.gauss(v, w / wp_y)
-
-                            p = round(p)
-                            q = round(q)
-
-                        else:
-                            p = q = 0
-
-                        x_e = x + p
-                        y_e = y + q
-
-                        if wrap:
-                            # toroidal boundary: charge re-enters the opposite edge
-                            result[i, x_e % num_x, y_e % num_y] += 1
-                        elif (0 <= x_e < num_x) and (0 <= y_e < num_y):
-                            result[i, x_e, y_e] += 1
-                        # otherwise the electron diffused off the sensor and is lost
+                    if z_ij < z_ff and wp_x > 0 and wp_y > 0:
+                        w = z_ff * math.sqrt(1 - z_ij / z_ff)
+                        _diffuse_electrons(
+                            result=result,
+                            i=i,
+                            x=x,
+                            y=y,
+                            m=m_ij,
+                            u=u,
+                            v=v,
+                            sigma_x=w / wp_x,
+                            sigma_y=w / wp_y,
+                            num_x=num_x,
+                            num_y=num_y,
+                            wrap=wrap,
+                            factor_multinomial=factor_multinomial,
+                        )
+                    else:
+                        # no diffusion: all of the electrons stay in the
+                        # pixel the photon was absorbed in
+                        result[i, x, y] += m_ij
 
     return result

--- a/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020_test.py
+++ b/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020_test.py
@@ -260,3 +260,71 @@ def test_electrons_measured_wrap():
     total_wrap = _ramanathan_2020.electrons_measured(**kwargs, wrap=True).sum(axis_xy)
 
     assert total_wrap > total_drop
+
+
+@pytest.mark.parametrize(
+    argnames="factor_multinomial",
+    argvalues=[
+        0,
+        np.inf,
+    ],
+)
+def test_electrons_measured_factor_multinomial(
+    factor_multinomial: float,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    The per-electron and multinomial paths of :func:`_diffuse_electrons`
+    sample the same distribution, so forcing either one should reproduce the
+    analytic charge-diffusion width.
+    """
+    monkeypatch.setattr(
+        _ramanathan_2020,
+        "_factor_multinomial",
+        factor_multinomial,
+    )
+
+    num = 41
+    axis_xy = ("pixel_x", "pixel_y")
+
+    absorption = 1 / u.um
+    thickness_substrate = 14 * u.um
+    thickness_depletion = 2 * u.um
+    width_pixel = 5 * u.um
+
+    photons = np.zeros((num, num))
+    photons[num // 2, num // 2] = 3000
+    photons = na.ScalarArray(photons << u.photon, axes=axis_xy).astype(int)
+
+    # A short wavelength, so that each photon liberates enough electrons
+    # (~680 pairs) to exercise the large-count regime of both paths.
+    electrons = _ramanathan_2020.electrons_measured(
+        photons_absorbed=photons,
+        wavelength=5 * u.AA,
+        absorption=absorption,
+        thickness_implant=0 * u.um,
+        thickness_depletion=thickness_depletion,
+        thickness_substrate=thickness_substrate,
+        width_pixel=width_pixel,
+        cce_backsurface=1,
+        axis_xy=axis_xy,
+        wrap=True,
+    )
+
+    offset_x = (na.arange(0, num, axis=axis_xy[0]) - num // 2) * width_pixel
+    offset_y = (na.arange(0, num, axis=axis_xy[1]) - num // 2) * width_pixel
+
+    total = electrons.sum(axis_xy)
+    mean_x = (electrons * offset_x).sum(axis_xy) / total
+    mean_y = (electrons * offset_y).sum(axis_xy) / total
+    var_x = (electrons * np.square(offset_x - mean_x)).sum(axis_xy) / total
+    var_y = (electrons * np.square(offset_y - mean_y)).sum(axis_xy) / total
+    std_measured = np.sqrt((var_x + var_y) / 2)
+
+    std_expected = optika.sensors.charge_diffusion(
+        absorption=absorption,
+        thickness_substrate=thickness_substrate,
+        thickness_depletion=thickness_depletion,
+    )
+
+    assert np.allclose(std_measured, std_expected, rtol=0.05)


### PR DESCRIPTION
## Summary

The inner loop of `_electrons_measured_numba` relocates each of a photon's electrons individually, which costs O(m) per photon. At short wavelengths a single photon liberates hundreds to thousands of pairs, and this loop dominates the Monte Carlo — it is a large part of why the `signal()` comparisons in #195 are so slow to iterate on.

Since the relocations are i.i.d. on integer pixel offsets, the counts landing at each offset are multinomial. The new `_diffuse_electrons` helper samples that multinomial directly when m is large: electrons are partitioned across a bounded window of x offsets via conditional binomials, then each occupied column across y offsets, with per-bin probabilities given by the Gaussian integrated over each pixel (an erf difference). This costs O(window) rather than O(m). Probability mass beyond the ±6σ window (~1e-9) folds into the edge bins, so charge is conserved exactly, and off-sensor columns/bins are dropped when `wrap=False`, matching the per-electron behavior.

**The brute-force path is retained**, as the small-m branch of the same function: per-photon, the sampler compares m against `_factor_multinomial` times the window area and takes whichever path is cheaper. Setting the module constant `_factor_multinomial` to `inf` forces per-electron sampling everywhere (the exact previous behavior), and `0` forces the multinomial path, so either can be pinned for testing.

No public API changes, no new files.

## Benchmarks

32×32 grid, e2v-CCD97-like parameters (`thickness_depletion=2 μm`, `thickness_substrate=14 μm`, `width_pixel=5 μm`, `wrap=True`), wall time per image; `auto` is the default crossover (`_factor_multinomial = 0.25`, tuned from these measurements):

| wavelength | photons/px | brute | multinomial | auto | speedup |
|---|---|---|---|---|---|
| 1.5 Å | 200 | 34.9 s | 11.0 s | 11.0 s | **3.2×** |
| 5.0 Å | 200 | 11.6 s | 7.1 s | 7.1 s | **1.6×** |
| 20 Å | 1000 | 14.1 s | 18.9 s | 14.1 s | 1.0× |
| 100 Å | 5000 | 14.5 s | 56.1 s | 14.5 s | 1.0× |
| 1000 Å | 20000 | 8.4 s | 75.7 s | 8.4 s | 1.0× |

The crossover tracks the faster path at every wavelength (`auto/best = 1.00` throughout), so long-wavelength workloads are unaffected.

## Validation

- Forced-path comparison over ~5×10⁷ electrons (3000 photons/trial at 5 Å): totals, spatial means, and spatial variances of the brute-force and multinomial paths agree within Monte Carlo noise (means to ~4×10⁻³ px, variances to ~2×10⁻³ relative).
- New `test_electrons_measured_factor_multinomial` forces each path via `monkeypatch` and checks the measured spread against the analytic `optika.sensors.charge_diffusion` width, at a wavelength short enough (~680 pairs/photon) to exercise the large-m regime.
- All 16 `electrons_measured` tests and the 40 downstream `_materials_test.py` tests touching `signal`/`electrons_measured`/`uncertainty` pass locally.

## Follow-up worth knowing about

While profiling I found that `probability_of_n_pairs` takes **~1.6 s per call** (for a 20-element PMF) and is recomputed on every `electrons_measured` call — for single-wavelength calls this fixed cost exceeds the entire electron loop. Caching it would speed up every Monte-Carlo-heavy workflow, including the #195 test loop, and is probably a bigger win than this PR for long-wavelength work. Left out of scope here since it touches evaluation caching rather than the sampler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q4461XE8hCcZCKsViMQC1