### PR TITLE
Cache the Ramanathan PMF and vectorize its temperature interpolation

### DIFF
--- a/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020.py
+++ b/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020.py
@@ -1,3 +1,4 @@
+import functools
 import pathlib
 import math
 import random
@@ -45,10 +46,17 @@ def _probability_of_n_pairs_from_file(
     )
 
 
+@functools.cache
 def _probability_of_n_pairs_ramanathan() -> na.FunctionArray[
     na.CartesianNdVectorArray,
     na.ScalarArray,
 ]:
+    """
+    Load the tabulated pair-creation PMF of :cite:t:`Ramanathan2020`.
+
+    The result is cached and shared between calls, so it should be treated
+    as read-only.
+    """
 
     directory = pathlib.Path(__file__).parent
     pn_000K = _probability_of_n_pairs_from_file(directory / "p0K.dat")
@@ -445,11 +453,35 @@ def probability_of_n_pairs(
     _temperature = pn.inputs.components["temperature"]
     _probability = pn.outputs
 
-    probability = na.interp(
-        x=temperature,
-        xp=_temperature,
-        fp=_probability,
+    # Interpolate over temperature by gathering the two bracketing samples
+    # and blending them, rather than with `na.interp`, which loops over the
+    # ~20,000 elements of the non-interpolated axes in Python.
+    # Rename the tabulated temperature axis so that it cannot collide with
+    # an axis of the same name on the `temperature` argument.
+    axis = "_temperature_interp"
+    _temperature = na.ScalarArray(_temperature.ndarray, axes=axis)
+    _probability = na.ScalarArray(
+        ndarray=_probability.ndarray,
+        axes=tuple(axis if ax == "temperature" else ax for ax in _probability.axes),
     )
+
+    num_temperature = _temperature.shape[axis]
+    index_upper = np.clip(
+        (temperature > _temperature).sum(axis),
+        a_min=1,
+        a_max=num_temperature - 1,
+    )
+    index_lower = index_upper - 1
+    t_lower = _temperature[{axis: index_lower}]
+    t_upper = _temperature[{axis: index_upper}]
+    weight = np.clip(
+        (temperature - t_lower) / (t_upper - t_lower),
+        a_min=0,
+        a_max=1,
+    )
+    p_lower = _probability[{axis: index_lower}]
+    p_upper = _probability[{axis: index_upper}]
+    probability = p_lower + weight * (p_upper - p_lower)
 
     probability = na.interp(
         x=energy,

--- a/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020_test.py
+++ b/optika/sensors/materials/_ramanathan_2020/_ramanathan_2020_test.py
@@ -99,6 +99,49 @@ def test_fano_factor_inf(
 
 
 @pytest.mark.parametrize(
+    argnames="wavelength",
+    argvalues=[
+        5 * u.AA,
+        na.geomspace(2, 5000, axis="wavelength", num=11) << u.AA,
+    ],
+)
+@pytest.mark.parametrize(
+    argnames="temperature",
+    argvalues=[
+        0 * u.K,
+        200 * u.K,
+        350 * u.K,
+        na.linspace(10, 290, axis="temperature", num=5) << u.K,
+    ],
+)
+def test_probability_of_n_pairs(
+    wavelength: u.Quantity | na.ScalarArray,
+    temperature: u.Quantity | na.ScalarArray,
+):
+    result = _ramanathan_2020.probability_of_n_pairs(
+        wavelength=wavelength,
+        temperature=temperature,
+    )
+
+    pn = _ramanathan_2020._probability_of_n_pairs_ramanathan()
+    expected = na.interp(
+        x=temperature.to(u.K, equivalencies=u.temperature()),
+        xp=pn.inputs.components["temperature"],
+        fp=pn.outputs,
+    )
+    expected = na.interp(
+        x=wavelength.to(u.eV, equivalencies=u.spectral()),
+        xp=pn.inputs.components["energy"],
+        fp=expected,
+    )
+
+    assert np.allclose(result.outputs, expected, atol=1e-12)
+
+    total = result.outputs.sum("num_electron")
+    assert np.allclose(total, 1)
+
+
+@pytest.mark.parametrize(
     argnames="photons_absorbed",
     argvalues=[
         na.broadcast_to((100 * u.photon).astype(int), dict(pixel_x=2, pixel_y=2)),


### PR DESCRIPTION
## Summary

Follow-up to the profiling in #196: `probability_of_n_pairs` took **~1.6 s per call**, a fixed overhead paid by every `electrons_measured` invocation regardless of photon count. For photon-light calls (unit tests, small ROIs, single-wavelength VMR checks) this intercept exceeded the entire Monte Carlo — a zero-photon `electrons_measured` call took 1.71 s. Together with #196 (which attacks the per-electron slope), this removes the intercept, and directly speeds up the #195 test loop.

## Where the 1.6 s went

| step | cost |
|---|---|
| parsing the three `.dat` tables, every call | 0.25 s |
| `na.interp` over the temperature axis | **1.35 s** |
| `na.interp` over the energy axis | 0.002 s |

The temperature interpolation is slow because `na.interp` loops over the ~20,000 elements of the non-interpolated `(wavelength, num_electron)` axes in Python — to interpolate at a single temperature.

## Changes

- **`_probability_of_n_pairs_ramanathan()` is now `functools.cache`d.** It takes no arguments and returns constant tabulated data, so the parse happens once per process. `quantum_yield_ideal` and `fano_factor` call it too and benefit equally. The docstring notes the returned data is shared and read-only.
- **The temperature interpolation is a vectorized gather-and-blend**: locate the bracketing samples with a broadcast comparison, gather both by named-array indexing, blend linearly, clamping outside the tabulated range exactly as `np.interp` does. The tabulated axis is renamed internally (`_temperature_interp`) so a `temperature` argument carrying an axis literally named `temperature` still works, as it did with `na.interp`.
- The (cheap) energy interpolation is left as `na.interp`.

No public API changes, no new files.

## Results

- `probability_of_n_pairs`: 1.60 s → **2.6 ms** warm (~600×)
- zero-photon `electrons_measured`: 1.71 s → **0.11 s**
- `quantum_yield_ideal` + `fano_factor` (cold interp, warm cache): 90 ms

## Validation

- New implementation matches the previous `na.interp` chain to **6×10⁻¹⁷** (one ulp) across scalar and array wavelengths and temperatures, including values outside the tabulated range and an argument axis named `temperature`.
- New `test_probability_of_n_pairs` (8 parametrized cases) pins the result to an `na.interp` reference and checks the PMF sums to 1.
- All 46 tests in `_ramanathan_2020_test.py` and the 48 downstream `_materials_test.py` tests touching `signal`/`electrons_measured`/`uncertainty`/`quantum_yield`/`fano` pass locally.

Merges independently of #196 (non-overlapping regions of the same files); whichever lands second rebases trivially.

The residual 0.11 s intercept is `absorption_effective`/`multilayer_efficiency` on the `_materials.py` side — left alone here, but worth a look if the fixed cost still matters after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q4461XE8hCcZCKsViMQC1