### PR TITLE
Add a BSD 3-Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2026, Roy T. Smart, Jacob D. Parker, and Charles C. Kankelborg
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ authors = [
 description = "A Python library for simulating optical systems, similar to Zemax"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
This repository has no license, which means the default of all rights reserved
applies: nobody has permission to use, modify, or redistribute it, even though
it is published on PyPI and imported by `esis`. This is the same change merged
as sun-data/regridding#54, sun-data/named-arrays#203, sun-data/colorsynth#11,
and sun-data/ndfilters#28.

This adds the BSD 3-Clause license, matching `numpy` and `astropy`, which
`optika` sits on top of. It also satisfies NASA SPD-41a, which asks that
software developed with Science Mission Directorate funding be released under a
permissive license, and its third clause forbids using the copyright holders'
names to endorse derived products.

## Changes

- `LICENSE`, the standard BSD 3-Clause text, with the copyright line
  `Copyright (c) 2023-2026, Roy T. Smart, Jacob D. Parker, and Charles C. Kankelborg`.
  Roy and Jacob are the committers; Charles is included at Roy's direction as
  the advisor on this work. 2023 is when the repository was created.
- `pyproject.toml` declares `license = "BSD-3-Clause"` and
  `license-files = ["LICENSE"]`, the PEP 639 form.

Verified by building a wheel from this branch: the metadata is
`Metadata-Version: 2.4` with `License-Expression: BSD-3-Clause` and
`License-File: LICENSE`, and the license is packaged at
`dist-info/licenses/LICENSE`, so PyPI will display it on the next release.
There is no `License ::` classifier to conflict with the expression, and
`ruff check .` passes.

## Worth knowing before merging

The copyright line names the people rather than Montana State University. MSU's
faculty handbook gives authors ownership of copyrightable works other than
commissioned courseware, which is the basis for that, but the university has
not been asked, and if it ever asserts ownership the line is an ordinary commit
to correct. Releasing permissively is the part that does not undo: copies
distributed under these terms stay licensed under them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)