### PR TITLE
Let a plot be drawn in a unit of the caller's choosing

### DIFF
--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -135,6 +135,7 @@ class AbstractAperture(
         transformation: None | na.transformations.AbstractTransformation = None,
         components: None | tuple[str, ...] = None,
         sag: None | optika.sags.AbstractSag = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> None | na.ScalarArray[npt.NDArray[None | matplotlib.lines.Line2D]]:
         if ax is None:
@@ -148,6 +149,9 @@ class AbstractAperture(
 
         if sag is not None:
             wire.z = sag(wire)
+
+        if unit is not None:
+            wire = wire.to(unit)
 
         kwargs_plot = self.kwargs_plot
         if kwargs_plot is None:

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -2,6 +2,7 @@ import dataclasses
 import pytest
 import numpy as np
 import matplotlib.axes
+import matplotlib.pyplot as plt
 import astropy.units as u
 import named_arrays as na
 import optika
@@ -487,3 +488,52 @@ class TestIsoscelesTrapezoidalAperture(
     AbstractTestAbstractIsoscelesTrapezoidalAperture,
 ):
     pass
+
+
+def _extent_plotted(
+    aperture: optika.apertures.AbstractAperture,
+    unit: None | u.UnitBase,
+) -> float:
+    """
+    How far from the origin the aperture is drawn.
+
+    The bare magnitude handed to matplotlib, which is what sets the scale it is
+    drawn at on an axes which does not understand units.
+    """
+    fig, ax = plt.subplots()
+    try:
+        aperture.plot(ax=ax, components=("x", "y"), unit=unit)
+        x = np.concatenate(
+            [
+                np.asarray(getattr(line.get_xdata(), "value", line.get_xdata()))
+                for line in ax.lines
+            ]
+        )
+        return float(np.max(np.abs(x)))
+    finally:
+        plt.close(fig)
+
+
+def test_plot_unit():
+    """
+    Asking for a unit draws every aperture to one scale.
+
+    Matplotlib is told about units by
+    :func:`astropy.visualization.quantity_support`, but that reconciles them
+    only on a 2D axes. On a 3D axes an aperture measured in microns is drawn a
+    thousand times larger than the same aperture measured in millimeters, and
+    the instrument around it collapses to a speck.
+    """
+    millimeters = optika.apertures.RectangularAperture(1 * u.mm)
+    micrometers = optika.apertures.RectangularAperture(1000 * u.um)
+
+    # the same aperture, described in two different units
+    assert _extent_plotted(millimeters, None) == pytest.approx(1)
+    assert _extent_plotted(micrometers, None) == pytest.approx(1000)
+
+    # which are drawn to one scale when a unit is asked for
+    assert _extent_plotted(millimeters, u.mm) == pytest.approx(1)
+    assert _extent_plotted(micrometers, u.mm) == pytest.approx(1)
+
+    # and converted, not merely relabelled
+    assert _extent_plotted(millimeters, u.um) == pytest.approx(1000)

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -202,6 +202,7 @@ class AbstractSurface(
         ax: None | matplotlib.axes.Axes | na.ScalarArray[npt.NDArray] = None,
         transformation: None | na.transformations.AbstractTransformation = None,
         components: None | tuple[str, ...] = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> dict[str, na.AbstractScalar]:
         sag = self.sag
@@ -228,6 +229,7 @@ class AbstractSurface(
                 transformation=transformation,
                 components=components,
                 sag=sag,
+                unit=unit,
                 **kwargs,
             )
 
@@ -237,6 +239,7 @@ class AbstractSurface(
                 transformation=transformation,
                 components=components,
                 sag=sag,
+                unit=unit,
                 **kwargs,
             )
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1696,6 +1696,7 @@ class AbstractSequentialSystem(
         plot_rays: bool = True,
         plot_rays_vignetted: bool = False,
         kwargs_rays: None | dict[str, Any] = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> na.AbstractScalar | dict[str, na.AbstractScalar]:
         """
@@ -1715,6 +1716,19 @@ class AbstractSequentialSystem(
             Boolean flag indicating whether to plot the vignetted rays.
         kwargs_rays
             Any additional keyword arguments to use when plotting the rays.
+        unit
+            The unit to express every plotted length in.
+
+            A system is free to describe its parts in whichever units suit
+            them, and a detector measured in microns alongside optics measured
+            in millimeters is quite normal. Matplotlib is told about units by
+            :func:`astropy.visualization.quantity_support`, which reconciles
+            them on a 2D axes but not on a 3D one, where a surface given in
+            microns is drawn a thousand times too large.
+
+            Giving a unit here converts everything to it first, so the system
+            is drawn to one scale whatever the axes. Leaving it as
+            :obj:`None`, the default, passes the lengths through as they are.
         kwargs
             Any additional keyword arguments to use when plotting the surfaces.
         """
@@ -1741,6 +1755,7 @@ class AbstractSequentialSystem(
                     ax=ax,
                     transformation=transformation,
                     components=components,
+                    unit=unit,
                     **kwargs,
                 )
             )
@@ -1755,8 +1770,12 @@ class AbstractSequentialSystem(
             if not plot_rays_vignetted:
                 where = raytrace.outputs.unvignetted[{self.axis_surface: ~0}]
 
+            position = raytrace.outputs.position
+            if unit is not None:
+                position = position.to(unit)
+
             result["rays"] = na.plt.plot(
-                raytrace.outputs.position,
+                position,
                 ax=ax,
                 axis=self.axis_surface,
                 where=where,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -716,3 +716,30 @@ class TestSequentialSystemGrazingSpectrograph(
         result = a.field_max
         assert np.abs(result.x - _radius_field_grazing) < 1e-6 * u.deg
         assert np.abs(result.y - _radius_field_grazing) < 1e-6 * u.deg
+
+
+def test_plot_unit():
+    """
+    The whole system is drawn in the unit asked for, rays included.
+
+    :func:`astropy.visualization.quantity_support` reconciles units on a 2D
+    axes but not on a 3D one, where a part described in microns is drawn a
+    thousand times larger than the millimeters around it.
+    """
+
+    def extent(unit: u.UnitBase) -> float:
+        """The largest magnitude handed to matplotlib, surfaces and rays alike."""
+        fig, ax = plt.subplots()
+        try:
+            _system_newtonian.plot(ax=ax, components=("z", "x"), unit=unit)
+            x = np.concatenate(
+                [
+                    np.asarray(getattr(line.get_xdata(), "value", line.get_xdata()))
+                    for line in ax.lines
+                ]
+            )
+            return float(np.max(np.abs(x)))
+        finally:
+            plt.close(fig)
+
+    assert extent(u.um) == pytest.approx(1000 * extent(u.mm))


### PR DESCRIPTION
A system is free to describe its parts in whichever units suit them, and a
detector measured in microns beside optics measured in millimeters is quite
normal. ESIS is built that way: its sensor comes from `msfc-ccd`, where a pixel
pitch is naturally microns, while the optics are millimeters.

Nothing reconciles those units on the way to matplotlib.
`astropy.visualization.quantity_support` does it on a 2D axes, but **not on a
3D one**, so a surface given in microns is drawn a thousand times too large:

```python
d = esis.flights.f1.optics.design(num_distribution=0)
ax = plt.figure().add_subplot(111, projection="3d")
d.system.plot(ax=ax, components=("y", "z", "x"), plot_rays=False)
ax.get_zlim()   # (-121491.1, 121491.1)
```

That is microns being read as millimeters. The instrument collapses to a speck
and the detectors land outside the frame entirely, with nothing to say so. It
is a quiet failure: the geometry is correct, only the scale it is drawn at is
wrong, so a layout figure simply comes out missing its detectors.

## The change

`plot` gains a `unit`, and converts every length to it before drawing: the
surfaces, both of their apertures, and the rays.

```python
d.system.plot(ax=ax, components=("y", "z", "x"), plot_rays=False, unit=u.mm)
ax.get_zlim()   # (-135.8, 135.8)
```

The default is unchanged, so nothing that works today moves.

This mirrors `_write_to_dxf`, which sits directly below `plot` in each of these
classes and has always taken a `unit` and converted. The plotting path was the
one that did not.

## Why not fix the sensor

The other option was to have the sensor describe itself in millimeters, as the
older `kgpy` model did, where the detector's clear width was computed as
`(width_pixels * shape_pixels).to(u.mm)`. That would fix ESIS and no one else,
and it puts the burden on how a part is specified rather than on how it is
drawn. Specifying a pixel pitch in microns should stay comfortable.

## Testing

`test_plot_unit` builds the same aperture twice, once in millimeters and once
in microns, and checks the magnitude handed to matplotlib. Without a unit the
two differ by a factor of a thousand; with one they agree; and asking for
microns converts rather than relabels. I checked it fails without the change.

The existing suites pass: 1641 in `apertures`, 451 in `systems/_sequential`.
