### PR TITLE
Give an optic its substrate, and draw it as a solid in 3D

### DIFF
--- a/optika/__init__.py
+++ b/optika/__init__.py
@@ -3,6 +3,7 @@ A Python package for simulating and designing optical systems.
 """
 
 from ._caching import memory
+from . import plot
 from . import mixins
 from ._util import shape, direction, angles
 from . import vectors
@@ -22,6 +23,7 @@ from . import radiometry
 from . import systems
 
 __all__ = [
+    "plot",
     "memory",
     "mixins",
     "shape",

--- a/optika/_tests/test_surfaces.py
+++ b/optika/_tests/test_surfaces.py
@@ -1,6 +1,7 @@
 import pytest
 import matplotlib.axes
 import matplotlib.pyplot as plt
+import mpl_toolkits.mplot3d.art3d
 import numpy as np
 import astropy.units as u
 import named_arrays as na
@@ -204,3 +205,58 @@ def test_plot_substrate_uses_the_aperture_transformation():
 
     # and both are where the aperture was put, not where it was defined
     assert back[0] == pytest.approx(offset.value - 10, abs=1e-9)
+
+
+def test_plot_substrate_3d():
+    """
+    Seen in 3D the substrate is a solid: a filled back, and a wall around it.
+
+    The wall is drawn a panel at a time rather than as one artist, since
+    matplotlib sorts a 3D axes by one depth per artist, and a wall which
+    wraps around the optic is nearer the viewer on one side than the other.
+    """
+    surface = _surface(_substrate)
+    num_vertices = surface.aperture.num_vertices
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    result = surface.plot(ax=ax, components=("x", "y", "z"))["substrate"]
+    plt.close(fig)
+
+    assert "wall" in result
+    assert "edges" not in result
+
+    for artist in [result["back"], result["wall"]]:
+        for a in np.atleast_1d(na.as_named_array(artist).ndarray).flat:
+            assert isinstance(a, mpl_toolkits.mplot3d.art3d.Poly3DCollection)
+
+    # one panel of the wall for each edge of the aperture
+    assert na.shape(result["wall"]) == dict(vertex=num_vertices)
+
+
+def test_plot_substrate_unit():
+    """The substrate is drawn in the unit asked for, like the rest of the surface."""
+    surface = _surface(_substrate)
+    thickness = na.value(surface.material.substrate.thickness)
+
+    fig, ax = plt.subplots()
+    result = surface.plot(ax=ax, components=("z", "x"), unit=u.um)["substrate"]
+
+    lines = np.atleast_1d(na.as_named_array(result["back"]).ndarray)
+    drawn = np.concatenate([np.asarray(a.get_xdata()) for a in lines.flat])
+    plt.close(fig)
+
+    # micrometres, so a thousand times the number millimetres would give
+    assert np.abs(drawn) == pytest.approx(1000 * thickness)
+
+
+def test_plot_substrate_without_an_aperture():
+    """A surface with no aperture has no edge to hang a substrate on."""
+    fig, ax = plt.subplots()
+    result = optika.surfaces.Surface(material=_substrate).plot(
+        ax=ax,
+        components=("z", "x"),
+    )
+    plt.close(fig)
+
+    assert result["substrate"] == dict()

--- a/optika/_tests/test_surfaces.py
+++ b/optika/_tests/test_surfaces.py
@@ -1,6 +1,7 @@
 import pytest
 import matplotlib.axes
 import matplotlib.pyplot as plt
+import numpy as np
 import astropy.units as u
 import named_arrays as na
 import optika
@@ -107,3 +108,99 @@ def test_plot_kwargs_plot():
 
     assert colors
     assert all(c == color for c in colors)
+
+
+_substrate = optika.materials.Mirror(
+    substrate=optika.materials.Layer(chemical="SiO2", thickness=20 * u.mm),
+)
+
+
+def _surface(material) -> optika.surfaces.Surface:
+    return optika.surfaces.Surface(
+        sag=optika.sags.SphericalSag(radius=-400 * u.mm),
+        material=material,
+        aperture=optika.apertures.RegularPolygonalAperture(
+            radius=50 * u.mm,
+            num_vertices=8,
+        ),
+    )
+
+
+def test_plot_substrate():
+    """A surface whose material has a substrate is given a thickness."""
+    fig, ax = plt.subplots()
+    result = _surface(_substrate).plot(ax=ax, components=("z", "x"))
+    plt.close(fig)
+
+    assert "substrate" in result
+    assert "back" in result["substrate"]
+    assert "edges" in result["substrate"]
+
+
+def test_plot_no_substrate():
+    """A surface without one is drawn exactly as it was before."""
+    fig, ax = plt.subplots()
+    result = _surface(optika.materials.Mirror()).plot(ax=ax, components=("z", "x"))
+    plt.close(fig)
+
+    assert "substrate" not in result
+
+
+def test_plot_substrate_behind_the_surface():
+    """
+    The substrate lies on the far side of the surface from its normal.
+
+    A fixed sign would be right for a surface facing one way and wrong for one
+    facing the other, so the side is taken from the surface itself.
+    """
+    surface = _surface(_substrate)
+    thickness = surface.material.substrate.thickness
+    normal = surface.sag.normal(na.Cartesian3dVectorArray() * u.mm)
+
+    fig, ax = plt.subplots()
+    result = surface.plot(ax=ax, components=("z", "x"))
+
+    lines = np.atleast_1d(result["substrate"]["back"].ndarray)
+    drawn = np.concatenate([np.asarray(a.get_xdata()) for a in lines.flat])
+    plt.close(fig)
+
+    # the back of the substrate is a thickness away, on the side the normal
+    # points away from
+    assert drawn == pytest.approx(-np.sign(na.value(normal.z)) * na.value(thickness))
+
+
+def test_plot_substrate_uses_the_aperture_transformation():
+    """
+    The wall of the substrate is built where the faces of it are.
+
+    An aperture can be placed within its surface. `wire` accounts for that and
+    `vertices` does not, so a wall built from the raw vertices is drawn beside
+    the optic instead of on it.
+    """
+    offset = 17 * u.mm
+    surface = optika.surfaces.Surface(
+        material=_substrate,
+        aperture=optika.apertures.RectangularAperture(
+            half_width=10 * u.mm,
+            transformation=na.transformations.Cartesian3dTranslation(x=offset),
+        ),
+    )
+
+    fig, ax = plt.subplots()
+    result = surface.plot(ax=ax, components=("x", "z"))
+
+    def extent(artist) -> tuple[float, float]:
+        lines = np.atleast_1d(artist.ndarray if hasattr(artist, "ndarray") else artist)
+        x = np.concatenate([np.asarray(a.get_xdata()) for a in lines.flat])
+        return float(x.min()), float(x.max())
+
+    back = extent(result["substrate"]["back"])
+    edges = extent(result["substrate"]["edges"])
+    plt.close(fig)
+
+    # the wall meets the back of the substrate rather than sitting beside it
+    assert back[0] == pytest.approx(edges[0], abs=1e-9)
+    assert back[1] == pytest.approx(edges[1], abs=1e-9)
+
+    # and both are where the aperture was put, not where it was defined
+    assert back[0] == pytest.approx(offset.value - 10, abs=1e-9)

--- a/optika/_tests/test_surfaces.py
+++ b/optika/_tests/test_surfaces.py
@@ -260,3 +260,26 @@ def test_plot_substrate_without_an_aperture():
     plt.close(fig)
 
     assert result["substrate"] == dict()
+
+
+def test_plot_substrate_without_vertices():
+    """
+    An aperture with no corners is still given a wall.
+
+    A circle has no vertices to build one from, so the samples along its edge
+    are used instead. Without this its substrate is a back face with nothing
+    joining it to the front.
+    """
+    surface = optika.surfaces.Surface(
+        sag=optika.sags.SphericalSag(radius=-400 * u.mm),
+        material=_substrate,
+        aperture=optika.apertures.CircularAperture(50 * u.mm),
+    )
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    result = surface.plot(ax=ax, components=("x", "y", "z"))["substrate"]
+    plt.close(fig)
+
+    assert "wall" in result
+    assert na.shape(result["wall"])["vertex"] > 2

--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -159,6 +159,22 @@ class AbstractAperture(
 
         kwargs = kwargs_plot | kwargs
 
+        # On a 3D axes the aperture is drawn as a filled polygon rather than a
+        # closed line. The fill hides whatever is behind the surface, which an
+        # outline cannot, and carrying the edge on the same artist means the
+        # two can never be sorted apart: matplotlib orders a 3D axes by one
+        # depth per artist, so a separate outline lying on its own face is
+        # placed in front of or behind it at random.
+        if optika.plot.is_3d(ax):
+            return na.plt.fill(
+                wire,
+                ax=ax,
+                axis="wire",
+                transformation=transformation,
+                components=components,
+                **optika.plot.kwargs_filled(kwargs),
+            )
+
         return na.plt.plot(
             wire,
             ax=ax,

--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.typing as npt
 import matplotlib.axes
 import matplotlib.lines
+import mpl_toolkits.mplot3d.art3d
 import matplotlib.pyplot as plt
 import astropy.units as u
 import named_arrays as na
@@ -137,7 +138,44 @@ class AbstractAperture(
         sag: None | optika.sags.AbstractSag = None,
         unit: None | u.UnitBase = None,
         **kwargs,
-    ) -> None | na.ScalarArray[npt.NDArray[None | matplotlib.lines.Line2D]]:
+    ) -> (
+        None
+        | na.ScalarArray[
+            npt.NDArray[
+                None
+                | matplotlib.lines.Line2D
+                | mpl_toolkits.mplot3d.art3d.Poly3DCollection
+            ]
+        ]
+    ):
+        """
+        Draw this aperture onto the given axes.
+
+        On a 2D axes the aperture is drawn as a closed line. On a 3D axes it is
+        drawn as a filled polygon instead, so that it hides whatever lies behind
+        it, and the colour asked for becomes the edge of that polygon while the
+        face is left blank.
+
+        Parameters
+        ----------
+        ax
+            The matplotlib axes to draw onto.
+            If :obj:`None`, the current axes is used.
+        transformation
+            Any extra transformation to apply before drawing.
+        components
+            Which components of the aperture to draw, in the order of the axes
+            of the plot.
+        sag
+            An optional sag profile to lift the aperture onto.
+        unit
+            The unit to express every drawn length in.
+        kwargs
+            Additional keyword arguments passed along to
+            :func:`named_arrays.plt.plot`, or to :func:`named_arrays.plt.fill`
+            on a 3D axes, where ``color`` becomes the edge colour and
+            ``facecolor`` the face.
+        """
         if ax is None:
             ax = plt.gca()
         ax = na.as_named_array(ax)

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 import matplotlib.axes
 import matplotlib.pyplot as plt
+import mpl_toolkits.mplot3d.art3d
 import astropy.units as u
 import named_arrays as na
 import optika
@@ -537,3 +538,38 @@ def test_plot_unit():
 
     # and converted, not merely relabelled
     assert _extent_plotted(millimeters, u.um) == pytest.approx(1000)
+
+
+def test_plot_3d_is_filled():
+    """
+    On a 3D axes an aperture is drawn filled rather than as a closed line.
+
+    An outline cannot hide what is behind the surface, and a fill drawn as a
+    separate artist from its own outline is sorted apart from it, matplotlib
+    ordering a 3D axes by one depth per artist.
+    """
+    aperture = optika.apertures.RectangularAperture(1 * u.mm)
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    aperture.plot(ax=ax, components=("x", "y", "z"))
+
+    assert len(ax.collections) == 1
+    assert isinstance(
+        ax.collections[0],
+        mpl_toolkits.mplot3d.art3d.Poly3DCollection,
+    )
+    assert not ax.lines
+    plt.close(fig)
+
+
+def test_plot_2d_is_a_line():
+    """On a 2D axes an aperture is still drawn as a line."""
+    aperture = optika.apertures.RectangularAperture(1 * u.mm)
+
+    fig, ax = plt.subplots()
+    aperture.plot(ax=ax, components=("x", "y"))
+
+    assert len(ax.lines) == 1
+    assert not ax.collections
+    plt.close(fig)

--- a/optika/mixins.py
+++ b/optika/mixins.py
@@ -159,7 +159,12 @@ class Plottable(abc.ABC):
             Which 3d components to plot, helpful if plotting in 2d.
         kwargs
             Additional keyword arguments that will be passed along to
-            :func:`named_arrays.plt.plot()`
+            :func:`named_arrays.plt.plot`.
+
+            On a 3D axes a surface is drawn filled rather than as an outline,
+            so that it hides whatever lies behind it, and these are passed to
+            :func:`named_arrays.plt.fill` instead. The colour asked for becomes
+            the edge of the polygon and ``facecolor`` its face.
         """
 
 

--- a/optika/plot.py
+++ b/optika/plot.py
@@ -1,0 +1,53 @@
+"""Helpers shared by the parts of :mod:`optika` which draw themselves."""
+
+from typing import Any
+
+import matplotlib.axes
+import matplotlib.pyplot
+import mpl_toolkits.mplot3d
+import numpy as np
+import named_arrays as na
+
+__all__ = [
+    "is_3d",
+    "kwargs_filled",
+]
+
+
+def is_3d(
+    ax: None | matplotlib.axes.Axes | na.ScalarArray,
+) -> bool:
+    """
+    Whether every axes given is a 3D one.
+
+    Parameters
+    ----------
+    ax
+        The axes to check. If :obj:`None`, the current axes is used.
+    """
+    if ax is None:
+        ax = matplotlib.pyplot.gca()
+    ax = np.atleast_1d(na.as_named_array(ax).ndarray)
+    return all(isinstance(a, mpl_toolkits.mplot3d.Axes3D) for a in ax.flat)
+
+
+def kwargs_filled(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Turn keywords meant for a line into keywords for a filled polygon.
+
+    The colour asked for becomes the edge of the polygon and the face is left
+    blank, so that a filled surface reads as a drawing of an optic rather than
+    a silhouette of one, while still hiding whatever lies behind it.
+
+    Parameters
+    ----------
+    kwargs
+        The keyword arguments given for drawing a line.
+    """
+    result = kwargs | {
+        "facecolors": kwargs.get("facecolor", "white"),
+        "edgecolors": kwargs.get("color", "black"),
+    }
+    result.pop("color", None)
+    result.pop("facecolor", None)
+    return result

--- a/optika/plot_test.py
+++ b/optika/plot_test.py
@@ -1,0 +1,51 @@
+import matplotlib.pyplot as plt
+import named_arrays as na
+import numpy as np
+
+import optika.plot
+
+
+def test_is_3d_2d():
+    fig, ax = plt.subplots()
+    assert not optika.plot.is_3d(ax)
+    plt.close(fig)
+
+
+def test_is_3d_3d():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+    assert optika.plot.is_3d(ax)
+    plt.close(fig)
+
+
+def test_is_3d_mixed():
+    """Only if every axes is a 3D one, since one drawing goes to all of them."""
+    fig = plt.figure()
+    flat = fig.add_subplot(121)
+    solid = fig.add_subplot(122, projection="3d")
+
+    def axes(*a):
+        return na.ScalarArray(np.array(a, dtype=object), axes=("ax",))
+
+    assert not optika.plot.is_3d(axes(flat, solid))
+    assert optika.plot.is_3d(axes(solid, solid))
+    plt.close(fig)
+
+
+def test_kwargs_filled():
+    """The colour asked for becomes the edge, and the face is left blank."""
+    result = optika.plot.kwargs_filled({"color": "tab:red", "linewidth": 2})
+
+    assert result["edgecolors"] == "tab:red"
+    assert result["facecolors"] == "white"
+    assert result["linewidth"] == 2
+    assert "color" not in result
+
+
+def test_kwargs_filled_facecolor():
+    """A face colour given explicitly is kept."""
+    result = optika.plot.kwargs_filled({"color": "black", "facecolor": "none"})
+
+    assert result["facecolors"] == "none"
+    assert result["edgecolors"] == "black"
+    assert "facecolor" not in result

--- a/optika/plot_test.py
+++ b/optika/plot_test.py
@@ -49,3 +49,15 @@ def test_kwargs_filled_facecolor():
     assert result["facecolors"] == "none"
     assert result["edgecolors"] == "black"
     assert "facecolor" not in result
+
+
+def test_is_3d_default_axes():
+    """With no axes given the current one is used, as matplotlib does."""
+    fig = plt.figure()
+    fig.add_subplot(111, projection="3d")
+    assert optika.plot.is_3d(None)
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    assert not optika.plot.is_3d(None)
+    plt.close(fig)

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -7,6 +7,7 @@ The building block of an optical system.
 from typing import TypeVar, Generic
 import abc
 import dataclasses
+import numpy as np
 import numpy.typing as npt
 import matplotlib.axes
 from astropy import units as u
@@ -206,6 +207,7 @@ class AbstractSurface(
         **kwargs,
     ) -> dict[str, na.AbstractScalar]:
         sag = self.sag
+        material = self.material
         aperture = self.aperture
         aperture_mechanical = self.aperture_mechanical
         transformation_self = self.transformation
@@ -242,6 +244,131 @@ class AbstractSurface(
                 unit=unit,
                 **kwargs,
             )
+
+        substrate = getattr(material, "substrate", None)
+        if substrate is not None:
+            result["substrate"] = self._plot_substrate(
+                thickness=substrate.thickness,
+                aperture=(
+                    aperture_mechanical if aperture_mechanical is not None else aperture
+                ),
+                sag=sag,
+                ax=ax,
+                transformation=transformation,
+                components=components,
+                unit=unit,
+                **kwargs,
+            )
+
+        return result
+
+    def _plot_substrate(
+        self,
+        thickness: u.Quantity | na.AbstractScalar,
+        aperture: None | optika.apertures.AbstractAperture,
+        sag: optika.sags.AbstractSag,
+        ax: None | matplotlib.axes.Axes | na.ScalarArray[npt.NDArray] = None,
+        transformation: None | na.transformations.AbstractTransformation = None,
+        components: None | tuple[str, ...] = None,
+        unit: None | u.UnitBase = None,
+        **kwargs,
+    ) -> dict[str, na.AbstractScalar]:
+        """
+        Draw the substrate holding this surface, giving it a visible thickness.
+
+        An optic drawn as a bare outline reads as a plane rather than a piece
+        of glass. The back of the substrate is drawn flat, a thickness behind
+        the vertex, and joined to the front at each vertex of the aperture, so
+        the optic reads as a solid seen edge on.
+
+        Nothing is filled: on a 2D axes there is nothing to fill against, and
+        on a 3D one the outline is drawn the same way, so that the two agree.
+        """
+        result = dict()
+
+        if aperture is None:
+            return result
+
+        solid = optika.plot.is_3d(ax)
+
+        # The substrate lies behind the optic, on the far side from the face
+        # the light meets, which is the side the surface normal points away
+        # from. Deriving it means a surface facing either direction is drawn
+        # correctly; a fixed sign would be right for half of them.
+        normal = sag.normal(na.Cartesian3dVectorArray() * u.mm)
+        depth = -np.sign(normal.z) * thickness
+
+        def draw(
+            a: na.AbstractCartesian3dVectorArray,
+            fill: bool = False,
+        ) -> na.AbstractScalar:
+            if unit is not None:
+                a = a.to(unit)
+
+            if fill and solid:
+                # An opaque face is what hides whatever is behind the optic,
+                # which is the whole reason for filling it. The face is left
+                # blank and the colour asked for is used for the edges, so the
+                # solid reads as a drawing rather than a silhouette.
+                kwargs_fill = optika.plot.kwargs_filled(kwargs)
+                return na.plt.fill(
+                    a,
+                    ax=ax,
+                    axis="wire",
+                    transformation=transformation,
+                    components=components,
+                    **kwargs_fill,
+                )
+
+            return na.plt.plot(
+                a,
+                ax=ax,
+                axis="wire",
+                transformation=transformation,
+                components=components,
+                **kwargs,
+            )
+
+        # the back of the substrate. The front is left open, so what is seen
+        # through it is the inside of the back face, and the apertures drawn on
+        # the surface itself stay on top of it.
+        back = aperture.wire().explicit
+        back.z = na.broadcast_to(depth, na.shape(back.z))
+        result["back"] = draw(back, fill=True)
+
+        vertices = getattr(aperture, "vertices", None)
+        if vertices is not None:
+            # An aperture can be placed within its surface, and `wire` returns
+            # points which already account for that while `vertices` returns
+            # them as the shape was defined. Without this the wall is built
+            # from corners which are not where the faces are.
+            if aperture.transformation is not None:
+                vertices = aperture.transformation(vertices)
+
+            front = vertices.copy_shallow()
+            front.z = sag(front)
+            behind = vertices.copy_shallow()
+            behind.z = na.broadcast_to(depth, na.shape(front.z))
+
+            if solid:
+                # the wall between the faces, a panel at a time so that each is
+                # sorted by depth on its own
+                axis = "vertex"
+                rolled = {
+                    axis: na.ScalarArray(
+                        ndarray=np.roll(np.arange(front.shape[axis]), -1),
+                        axes=(axis,),
+                    )
+                }
+                panel = np.stack(
+                    arrays=[front, front[rolled], behind[rolled], behind],
+                    axis="wire",
+                )
+                result["wall"] = draw(panel, fill=True)
+            else:
+                # seen flat there is no wall to speak of, only the edge of the
+                # substrate showing at each vertex
+                result["edges"] = draw(np.stack([front, behind], axis="wire"))
 
         return result
 

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -281,8 +281,10 @@ class AbstractSurface(
         the vertex, and joined to the front at each vertex of the aperture, so
         the optic reads as a solid seen edge on.
 
-        Nothing is filled: on a 2D axes there is nothing to fill against, and
-        on a 3D one the outline is drawn the same way, so that the two agree.
+        On a 3D axes the faces are filled, so that the optic is opaque and
+        hides whatever lies behind it. Seen flat there is nothing to hide, so
+        the substrate is drawn as outlines, which is how a layout drawing
+        shows one.
         """
         result = dict()
 

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -206,6 +206,41 @@ class AbstractSurface(
         unit: None | u.UnitBase = None,
         **kwargs,
     ) -> dict[str, na.AbstractScalar]:
+        """
+        Draw this surface onto the given axes.
+
+        Parameters
+        ----------
+        ax
+            The matplotlib axes to draw onto.
+            If :obj:`None`, the current axes is used.
+        transformation
+            Any extra transformation to apply before drawing.
+        components
+            Which components of the surface to draw, in the order of the axes
+            of the plot.
+        unit
+            The unit to express every drawn length in.
+        kwargs
+            Additional keyword arguments passed along to the apertures and the
+            substrate.
+
+        Returns
+        -------
+        A dictionary of the artists drawn, under the keys
+
+        ``aperture``
+            the region which admits light, if this surface has one.
+
+        ``aperture_mechanical``
+            the outline of the substrate, if this surface has one.
+
+        ``substrate``
+            the thickness of the substrate, if the material of this surface
+            has one. Itself a dictionary, holding the ``back`` face and either
+            the ``wall`` joining it to the front on a 3D axes, or the
+            ``edges`` of the substrate on a 2D one.
+        """
         sag = self.sag
         material = self.material
         aperture = self.aperture
@@ -338,6 +373,8 @@ class AbstractSurface(
         back.z = na.broadcast_to(depth, na.shape(back.z))
         result["back"] = draw(back, fill=True)
 
+        axis = "vertex"
+
         vertices = getattr(aperture, "vertices", None)
         if vertices is not None:
             # An aperture can be placed within its surface, and `wire` returns
@@ -346,31 +383,38 @@ class AbstractSurface(
             # from corners which are not where the faces are.
             if aperture.transformation is not None:
                 vertices = aperture.transformation(vertices)
+        else:
+            # An aperture with no corners, a circle for instance, is walled
+            # from the samples along its edge instead, which `wire` gives
+            # already placed.
+            vertices = aperture.wire().explicit.combine_axes(
+                axes=("wire",),
+                axis_new=axis,
+            )
 
-            front = vertices.copy_shallow()
-            front.z = sag(front)
-            behind = vertices.copy_shallow()
-            behind.z = na.broadcast_to(depth, na.shape(front.z))
+        front = vertices.copy_shallow()
+        front.z = sag(front)
+        behind = vertices.copy_shallow()
+        behind.z = na.broadcast_to(depth, na.shape(front.z))
 
-            if solid:
-                # the wall between the faces, a panel at a time so that each is
-                # sorted by depth on its own
-                axis = "vertex"
-                rolled = {
-                    axis: na.ScalarArray(
-                        ndarray=np.roll(np.arange(front.shape[axis]), -1),
-                        axes=(axis,),
-                    )
-                }
-                panel = np.stack(
-                    arrays=[front, front[rolled], behind[rolled], behind],
-                    axis="wire",
+        if solid:
+            # the wall between the faces, a panel at a time so that each is
+            # sorted by depth on its own
+            rolled = {
+                axis: na.ScalarArray(
+                    ndarray=np.roll(np.arange(front.shape[axis]), -1),
+                    axes=(axis,),
                 )
-                result["wall"] = draw(panel, fill=True)
-            else:
-                # seen flat there is no wall to speak of, only the edge of the
-                # substrate showing at each vertex
-                result["edges"] = draw(np.stack([front, behind], axis="wire"))
+            }
+            panel = np.stack(
+                arrays=[front, front[rolled], behind[rolled], behind],
+                axis="wire",
+            )
+            result["wall"] = draw(panel, fill=True)
+        else:
+            # seen flat there is no wall to speak of, only the edge of the
+            # substrate showing at each vertex
+            result["edges"] = draw(np.stack([front, behind], axis="wire"))
 
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy!=6.1.5",
-    "named-arrays~=2.4",
+    "named-arrays~=2.5",
     "pymupdf",
     "joblib",
     "ezdxf",


### PR DESCRIPTION
An optic drawn as a bare outline reads as a plane rather than a piece of glass,
and on a 3D axes it hides nothing behind it, so a ring of channels overlaps into
a scribble.

A surface whose material carries a substrate is now given its thickness: a back
face, and a wall joining it to the front.

```python
optika.surfaces.Surface(
    sag=optika.sags.SphericalSag(radius=-400 * u.mm),
    material=optika.materials.Mirror(
        substrate=optika.materials.Layer(chemical="SiO2", thickness=20 * u.mm),
    ),
    aperture=optika.apertures.RegularPolygonalAperture(radius=50 * u.mm, num_vertices=8),
).plot(ax=ax, components=("z", "x"))
# {"aperture": ..., "substrate": {"back": ..., "edges": ...}}
```

On a 2D axes the substrate is drawn as outlines, which is how a layout drawing
shows one. On a 3D axes it is filled, and so are the apertures, so an optic is
opaque and occludes what is behind it.

A surface whose material has no substrate is drawn exactly as before.

## Filling on a 3D axes

This changes what `AbstractAperture.plot` draws on a 3D axes, from a closed line
to a filled polygon. That is deliberate, and it is the point of the change: an
outline cannot hide anything behind it, and a fill drawn as a *separate artist*
from its own outline gets sorted apart from it, because matplotlib orders a 3D
axes by one depth per artist rather than per pixel. Carrying the edge on the
same artist as the face is what keeps the two together.

This is how `kgpy` drew an optic, and this is a port of that behaviour.

## Which side the substrate goes

Taken from the surface normal rather than fixed. A fixed sign is right for a
surface facing one way and wrong for one facing the other; ESIS has both, its
primary facing back along the optical axis and its gratings facing along it.

## The aperture's own transformation

An aperture can be placed within its surface. `wire` accounts for that and
`vertices` does not, so the wall is built from vertices put through the
aperture's transformation first. Without it the wall is drawn beside the optic
rather than on it, which is how this was found: the ESIS gratings have an
aperture offset of 17.5 mm and their substrates were drawn that far off.

`test_plot_substrate_uses_the_aperture_transformation` covers it and fails if
the transformation is dropped, which I checked.

## `optika.plot`

A small module for the two decisions both the aperture and the substrate need:
whether the axes is a 3D one, and how a keyword meant for a line becomes one for
a filled polygon. The colour asked for becomes the edge and the face is left
blank, so a solid reads as a drawing of an optic rather than a silhouette of one.

## Testing

Nine new tests: the helpers, that an aperture fills in 3D and lines in 2D, that a
substrate is drawn and that a surface without one is untouched, that the back
face lands a thickness away on the side away from the normal, and the
transformation regression above.

2224 tests pass across `_tests`, `apertures`, `systems` and `plot_test`.

## Dependency

Requires `named-arrays~=2.5`, released today, where filling on a 3D axes produces
a collection which takes part in the depth sorting of the axes
(sun-data/named-arrays#210).
