### PR TITLE
Cover the last twenty-nine lines

### DIFF
--- a/optika/_tests/test_propagators.py
+++ b/optika/_tests/test_propagators.py
@@ -1,6 +1,8 @@
 import pytest
 import abc
 import numpy as np
+import astropy.units as u
+import named_arrays as na
 import optika.propagators
 import optika.rays._tests.test_ray_vectors
 
@@ -30,3 +32,31 @@ class AbstractTestAbstractLightPropagator(
     AbstractTestAbstractRayPropagator,
 ):
     pass
+
+
+_surface = optika.surfaces.Surface(
+    sag=optika.sags.SphericalSag(radius=-100 * u.mm),
+    transformation=na.transformations.Cartesian3dTranslation(z=100 * u.mm),
+)
+"""One thing which knows how to propagate rays."""
+
+_rays = optika.rays.RayVectorArray(
+    wavelength=500 * u.nm,
+    position=na.Cartesian3dVectorArray(0, 1, 0) * u.mm,
+    direction=na.Cartesian3dVectorArray(0, 0, 1),
+)
+
+
+def test_propagate_rays_one():
+    """A lone propagator is taken as a sequence of one, not iterated over."""
+    result = optika.propagators.propagate_rays(_surface, _rays)
+
+    expected = optika.propagators.propagate_rays([_surface], _rays)
+    assert np.all(result.position == expected.position)
+
+
+def test_accumulate_rays_one():
+    """The same, for the version which keeps the rays at every propagator."""
+    result = optika.propagators.accumulate_rays(_surface, _rays, axis="surface")
+
+    assert na.shape(result) == dict(surface=1)

--- a/optika/_tests/test_surfaces.py
+++ b/optika/_tests/test_surfaces.py
@@ -1,5 +1,6 @@
 import pytest
 import matplotlib.axes
+import matplotlib.pyplot as plt
 import astropy.units as u
 import named_arrays as na
 import optika
@@ -89,3 +90,20 @@ class TestSurface(
     AbstractTestAbstractSurface,
 ):
     pass
+
+
+def test_plot_kwargs_plot():
+    """A surface can carry the keywords it is to be drawn with."""
+    color = "tab:red"
+    surface = optika.surfaces.Surface(
+        aperture=optika.apertures.CircularAperture(10 * u.mm),
+        kwargs_plot=dict(color=color),
+    )
+
+    fig, ax = plt.subplots()
+    surface.plot(ax=ax, components=("x", "y"))
+    colors = [line.get_color() for line in ax.lines]
+    plt.close(fig)
+
+    assert colors
+    assert all(c == color for c in colors)

--- a/optika/rays/_tests/test_ray_functions.py
+++ b/optika/rays/_tests/test_ray_functions.py
@@ -1,0 +1,21 @@
+import astropy.units as u
+import named_arrays as na
+import optika
+
+
+def test_type_explicit():
+    """
+    The explicit form of a ray function is a ray function.
+
+    :mod:`named_arrays` asks an array which class to build when it needs a
+    concrete one, and the answer for any ray function is this class.
+    """
+    result = optika.rays.RayFunctionArray(
+        inputs=optika.vectors.ObjectVectorArray(wavelength=500 * u.nm),
+        outputs=optika.rays.RayVectorArray(
+            wavelength=500 * u.nm,
+            position=na.Cartesian3dVectorArray(0, 0, 0) * u.mm,
+        ),
+    )
+
+    assert result.type_explicit is optika.rays.RayFunctionArray

--- a/optika/rays/_tests/test_ray_vectors.py
+++ b/optika/rays/_tests/test_ray_vectors.py
@@ -287,3 +287,62 @@ class TestRayVectorArray(
         value: float | na.ScalarArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+_rays = rays[0]
+"""A single set of rays, for the operations which take one."""
+
+_vector_2d = na.Cartesian2dVectorArray(1, 1) * u.mm
+"""A vector which rays cannot be combined with, having the wrong components."""
+
+
+def test__array_matmul__scalar():
+    """Multiplying by a scalar is left to the base class, which can do it."""
+    result = _rays @ 2
+
+    assert result.position == 2 * _rays.position
+    assert result.direction == 2 * _rays.direction
+
+
+@pytest.mark.parametrize(
+    argnames="x1,x2",
+    argvalues=[
+        (_rays, _vector_2d),
+        (_vector_2d, _rays),
+    ],
+)
+def test__array_matmul__unsupported(x1, x2):
+    """Rays and a vector of other components cannot be multiplied together."""
+    assert x1 @ x2 is None
+
+
+def test__array_matmul__neither():
+    """
+    Asked about two things which are not rays, the rays decline to answer.
+
+    Only reachable by calling the method directly, since matmul is dispatched
+    to this class only when one of its operands is a set of rays.
+    """
+    assert _rays.__array_matmul__(1, 2) is NotImplemented
+
+
+@pytest.mark.parametrize(
+    argnames="x1,x2",
+    argvalues=[
+        (_rays, _vector_2d),
+        (_vector_2d, _rays),
+    ],
+)
+def test__array_add__unsupported(x1, x2):
+    """Rays and a vector of other components cannot be added together."""
+    with pytest.raises(TypeError):
+        x1 + x2
+
+
+def test__array_add__neither():
+    """
+    Asked about two things which are not rays, the rays decline to answer.
+
+    Only reachable by calling the method directly, as with matmul above.
+    """
+    assert _rays.__array_add__(1, 2) is NotImplemented

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -100,7 +100,9 @@ class AbstractSequentialSystem(
         obj = self.object
         if obj is not None:
             result = [obj]
-        else:
+        else:  # pragma: nocover
+            # every concrete system fills in an object surface if it is given
+            # none, so this is here for the sake of a subclass which does not
             result = []
 
         result += list(self.surfaces)
@@ -307,7 +309,7 @@ class AbstractSequentialSystem(
         The index of the field stop in :attr:`surfaces_all`.
         """
         indices = self._indices_field_stop
-        if not indices:
+        if not indices:  # pragma: nocover
             raise ValueError(
                 "Field stop is not defined for this system."
                 "Set `is_field_stop=True` for at least one surface in this system."
@@ -417,9 +419,11 @@ class AbstractSequentialSystem(
         indices_pupil_stop = self._indices_pupil_stop
         indices_field_stop = self._indices_field_stop
 
-        if not indices_pupil_stop:
+        # both stops have been looked up by the caller, which raises a
+        # fuller message of its own if either is missing
+        if not indices_pupil_stop:  # pragma: nocover
             raise ValueError("pupil not defined")
-        if not indices_field_stop:
+        if not indices_field_stop:  # pragma: nocover
             raise ValueError("field stop not defined")
 
         while indices_pupil_stop and indices_field_stop:
@@ -492,7 +496,7 @@ class AbstractSequentialSystem(
                     )
                     return surface_first.sag(position)
 
-            else:
+            else:  # pragma: nocover
                 raise ValueError(f"unrecognized input grid unit, {na.unit(grid_first)}")
 
             # Seed the free ray component by aiming each ray at its own
@@ -551,7 +555,7 @@ class AbstractSequentialSystem(
                 component_target = "position"
             elif na.unit(grid_last).is_equivalent(u.dimensionless_unscaled):
                 component_target = "direction"
-            else:
+            else:  # pragma: nocover
                 raise ValueError(f"unrecognized output grid unit, {na.unit(grid_last)}")
 
             # The residual of the root-finding problem has the same units as

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1,3 +1,4 @@
+import dataclasses
 import matplotlib.pyplot as plt
 import pytest
 import numpy as np
@@ -743,3 +744,119 @@ def test_plot_unit():
             plt.close(fig)
 
     assert extent(u.um) == pytest.approx(1000 * extent(u.mm))
+
+
+def test_plot_kwargs_plot():
+    """A system can carry the keywords its surfaces are to be drawn with."""
+    color = "tab:red"
+    system = dataclasses.replace(
+        _system_newtonian,
+        kwargs_plot=dict(color=color),
+    )
+
+    fig, ax = plt.subplots()
+    system.plot(ax=ax, components=("z", "x"), plot_rays=False)
+    colors = [line.get_color() for line in ax.lines]
+    plt.close(fig)
+
+    assert colors
+    assert all(c == color for c in colors)
+
+
+def test_field_stop_default():
+    """
+    With no surface marked as the field stop, the first one becomes it.
+
+    A system needs a field stop to define its field of view, so rather than
+    refuse to trace a system which does not name one, the object surface is
+    taken to be it.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=_surfaces,
+        sensor=dataclasses.replace(_sensor, is_field_stop=False),
+        grid_input=_grid_input,
+    )
+
+    assert system.index_field_stop == 0
+    assert system.surfaces_all[0].is_field_stop
+
+
+def test_index_pupil_stop_undefined():
+    """
+    A system which names no pupil stop cannot say where its pupil is.
+
+    Unlike the field stop there is no sensible surface to fall back on, since
+    the pupil is a property of the optics rather than of the frame.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=[dataclasses.replace(_surfaces[0], is_pupil_stop=False)],
+        sensor=_sensor,
+        grid_input=_grid_input,
+    )
+
+    with pytest.raises(ValueError, match="Pupil stop is not defined"):
+        system.index_pupil_stop
+
+
+_object_translated = optika.surfaces.Surface(
+    aperture=optika.apertures.CircularAperture(10 * u.mm),
+    transformation=na.transformations.Cartesian3dTranslation(z=-10 * u.mm),
+)
+"""An object surface placed away from the origin of the system."""
+
+
+def test_object_transformation():
+    """
+    The rays start on the object surface wherever that surface has been put.
+
+    The object carries its own transformation, like any other surface, and the
+    rays are given in the coordinates of the system rather than of the object.
+    """
+    system = optika.systems.SequentialSystem(
+        object=_object_translated,
+        surfaces=_surfaces,
+        sensor=_sensor,
+        grid_input=_grid_input,
+    )
+
+    raytrace = system.raytrace(axis="surface")
+    z = raytrace.outputs.position.z[dict(surface=0)]
+
+    assert np.all(z == _object_translated.transformation.z)
+
+
+def test_stops_afocal():
+    """
+    A system whose image is at infinity is solved in angle at the far stop.
+
+    The stop nearer the object is measured in millimeters and the one further
+    away in direction cosines, so the rays are matched to the second stop by
+    the direction they leave in rather than by where they land.
+    """
+    system = optika.systems.SequentialSystem(
+        object=optika.surfaces.Surface(
+            aperture=optika.apertures.CircularAperture(1 * u.mm),
+            is_pupil_stop=True,
+        ),
+        surfaces=[
+            optika.surfaces.Surface(
+                name="exit",
+                aperture=optika.apertures.CircularAperture(0.05),
+                is_field_stop=True,
+                transformation=na.transformations.Cartesian3dTranslation(
+                    z=100 * u.mm,
+                ),
+            ),
+        ],
+        grid_input=_grid_input,
+    )
+
+    result = system.rayfunction_stops
+
+    # the rays leave at every angle the far stop admits, and from everywhere
+    # on the near one
+    direction = np.max(np.abs(result.outputs.direction.x))
+    position = np.max(np.abs(result.outputs.position.x))
+
+    assert float(na.value(direction).ndarray) == pytest.approx(0.05)
+    assert float(na.value(position.to(u.mm)).ndarray) == pytest.approx(1)

--- a/optika/vectors/_tests/test_vectors_field.py
+++ b/optika/vectors/_tests/test_vectors_field.py
@@ -147,3 +147,11 @@ class TestFieldVectorArray(
         value: optika.vectors.AbstractFieldVectorArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+def test_from_scalar():
+    """Without a vector to be like, the class asked is the class built."""
+    result = optika.vectors.FieldVectorArray.from_scalar(2 * u.mm)
+
+    assert isinstance(result, optika.vectors.FieldVectorArray)
+    assert result.field == 2 * u.mm

--- a/optika/vectors/_tests/test_vectors_object.py
+++ b/optika/vectors/_tests/test_vectors_object.py
@@ -152,3 +152,13 @@ class TestObjectVectorArray(
         value: optika.vectors.AbstractObjectVectorArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+def test_from_scalar():
+    """Without a vector to be like, the class asked is the class built."""
+    result = optika.vectors.ObjectVectorArray.from_scalar(2)
+
+    assert isinstance(result, optika.vectors.ObjectVectorArray)
+    assert result.wavelength == 2
+    assert result.field == 2
+    assert result.pupil == 2

--- a/optika/vectors/_tests/test_vectors_polarization.py
+++ b/optika/vectors/_tests/test_vectors_polarization.py
@@ -150,3 +150,12 @@ class TestPolarizationVectorArray(
         value: optika.vectors.AbstractPolarizationVectorArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+def test_from_scalar():
+    """Without a vector to be like, the class asked is the class built."""
+    result = optika.vectors.PolarizationVectorArray.from_scalar(2)
+
+    assert isinstance(result, optika.vectors.PolarizationVectorArray)
+    assert result.s == 2
+    assert result.p == 2

--- a/optika/vectors/_tests/test_vectors_pupil.py
+++ b/optika/vectors/_tests/test_vectors_pupil.py
@@ -147,3 +147,11 @@ class TestPupilVectorArray(
         value: optika.vectors.AbstractPupilVectorArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+def test_from_scalar():
+    """Without a vector to be like, the class asked is the class built."""
+    result = optika.vectors.PupilVectorArray.from_scalar(2 * u.mm)
+
+    assert isinstance(result, optika.vectors.PupilVectorArray)
+    assert result.pupil == 2 * u.mm

--- a/optika/vectors/_tests/test_vectors_scene.py
+++ b/optika/vectors/_tests/test_vectors_scene.py
@@ -146,3 +146,12 @@ class TestSceneVectorArray(
         value: optika.vectors.AbstractSceneVectorArray,
     ):
         super().test__setitem__(array=array, item=item, value=value)
+
+
+def test_from_scalar():
+    """Without a vector to be like, the class asked is the class built."""
+    result = optika.vectors.SceneVectorArray.from_scalar(2)
+
+    assert isinstance(result, optika.vectors.SceneVectorArray)
+    assert result.wavelength == 2
+    assert result.field == 2


### PR DESCRIPTION
`main` sits at 99.58%: 29 lines across ten files which no test reaches. This
brings it to 100%, by testing 23 of them and marking the other six as
unreachable.

## Tested

**`from_scalar` without a vector to be like** (5 lines, one per vector type).
Every call in the tests passes `like`, so the branch which builds the class it
was asked for rather than the class it was handed was never taken.

**A lone propagator** (2 lines). `propagate_rays` and `accumulate_rays` both
accept either one propagator or a sequence of them, and only the sequence was
tested.

**`RayFunctionArray.type_explicit`** (1 line), which is how `named_arrays` asks
an array what class to build when it needs a concrete one. New file,
`optika/rays/_tests/test_ray_functions.py`.

**Rays declining an operation they cannot do** (7 lines). Rays know how to be
multiplied by a matrix and shifted by a 3D vector; asked for anything else they
answer `NotImplemented` so that Python can try the other operand. Two of the
seven can only be reached by calling the method directly, since the dispatcher
sends the call here only when one operand is a set of rays; the tests say so.

**`kwargs_plot`** (2 lines), the keywords a surface or a system carries to be
drawn with, which nothing was passing.

**A system which names no field stop** (1 line). One is needed to define the
field of view, so the object surface is made the field stop rather than the
trace refusing to run.

**A system which names no pupil stop** (1 line). There is no surface to fall
back on here, since the pupil belongs to the optics rather than to the frame,
so this raises.

**An object surface with a transformation** (2 lines). Every object surface in
the tests sat at the origin, so the two places which put the rays back into the
coordinates of the system went untested. The test places the object 10 mm
behind the origin and checks the rays start there.

**A system whose image is at infinity** (2 lines). When the further of the two
stops is measured in direction cosines rather than millimeters, the rays are
matched to it by the direction they leave in rather than by where they land.
The test is the smallest system with that shape: an object with a millimeter
aperture as the pupil stop, and a plane with an angular aperture as the field
stop.

## Marked unreachable

Six lines are guards which no caller can trip, so they are marked
`# pragma: nocover`, as 35 lines elsewhere in this package already are. Each
one now says in a comment why it cannot fire:

- `surfaces_all` building an empty list when there is no object surface. Every
  concrete system fills one in; the branch is there for a subclass which
  does not.
- `index_field_stop` raising when no field stop is named, which `surfaces_all`
  has already made impossible by naming one itself.
- the two matching checks inside `_calc_rayfunction_stops_only`, which repeat
  what its only caller has already looked up, and with a shorter message.
- the two "unrecognized grid unit" errors, which need an aperture measured in
  something that is neither a length nor an angle. The same guard on
  `object_is_at_infinity` was already marked this way.

Deleting them would be the alternative, but they are a real check on a subclass
which overrides `surfaces_all`, so they are worth keeping.

## Note

Nothing in `optika` changed except six comments. Everything else here is tests.
