### PR TITLE
Let a raytrace skip the efficiency of each surface

### DIFF
--- a/optika/propagators.py
+++ b/optika/propagators.py
@@ -19,6 +19,7 @@ __all__ = [
 def propagate_rays(
     propagators: AbstractRayPropagator | Sequence[AbstractRayPropagator],
     rays: optika.rays.RayVectorArray,
+    efficiency: bool = True,
 ) -> optika.rays.RayVectorArray:
     """
     Iterate through a sequence of ray propagators, calling
@@ -31,12 +32,18 @@ def propagate_rays(
         A sequence of ray propagators to interact with `rays`.
     rays
         The input rays to propagate through the sequence.
+    efficiency
+        A boolean flag indicating whether to accumulate the efficiency of
+        each propagator into
+        :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+        If :obj:`False`, the intensity of the result is meaningless, but the
+        geometry is unchanged and much cheaper to compute.
     """
     if isinstance(propagators, AbstractRayPropagator):
         propagators = [propagators]
 
     for propagator in propagators:
-        rays = propagator.propagate_rays(rays)
+        rays = propagator.propagate_rays(rays, efficiency=efficiency)
 
     return rays
 
@@ -45,6 +52,7 @@ def accumulate_rays(
     propagators: AbstractRayPropagator | Sequence[AbstractRayPropagator],
     rays: optika.rays.RayVectorArray,
     axis: str,
+    efficiency: bool = True,
 ) -> optika.rays.RayVectorArray:
     """
     Iterate through a sequence of ray propagators, calling
@@ -59,13 +67,19 @@ def accumulate_rays(
         The input rays to propagate through the sequence.
     axis
         The new logical axis representing the sequence of propagators.
+    efficiency
+        A boolean flag indicating whether to accumulate the efficiency of
+        each propagator into
+        :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+        If :obj:`False`, the intensity of the result is meaningless, but the
+        geometry is unchanged and much cheaper to compute.
     """
     if isinstance(propagators, AbstractRayPropagator):
         propagators = [propagators]
 
     result = []
     for propagator in propagators:
-        rays = propagator.propagate_rays(rays)
+        rays = propagator.propagate_rays(rays, efficiency=efficiency)
         result.append(rays)
 
     result = na.stack(result, axis=axis)
@@ -90,6 +104,7 @@ class AbstractRayPropagator(
     def propagate_rays(
         self,
         rays: optika.rays.AbstractRayVectorArray,
+        efficiency: bool = True,
     ) -> optika.rays.AbstractRayVectorArray:
         """
         For the given input rays, calculate new rays based off of their
@@ -99,6 +114,12 @@ class AbstractRayPropagator(
         ----------
         rays
             A set of input rays that will interact with this object.
+        efficiency
+            A boolean flag indicating whether to accumulate the efficiency of
+            this object into
+            :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+            If :obj:`False`, the intensity of the result is meaningless, but
+            the geometry is unchanged and much cheaper to compute.
         """
 
 

--- a/optika/sags/_abc.py
+++ b/optika/sags/_abc.py
@@ -109,14 +109,16 @@ class AbstractSag(
     def propagate_rays(
         self,
         rays: optika.rays.AbstractRayVectorArray,
+        efficiency: bool = True,
     ) -> optika.rays.AbstractRayVectorArray:
 
         result = self.intercept(rays)
 
-        displacement = result.position - rays.position
+        if efficiency:
+            displacement = result.position - rays.position
 
-        f = np.exp(-result.attenuation * displacement.length)
+            f = np.exp(-result.attenuation * displacement.length)
 
-        result.intensity = f * result.intensity
+            result.intensity = f * result.intensity
 
         return result

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -123,6 +123,7 @@ class AbstractSurface(
     def propagate_rays(
         self,
         rays: optika.rays.RayVectorArray,
+        efficiency: bool = True,
     ) -> optika.rays.RayVectorArray:
         r"""
         Refract, reflect, and/or diffract the given rays off of this surface
@@ -131,6 +132,14 @@ class AbstractSurface(
         ----------
         rays
             A set of input rays that will interact with this surface.
+        efficiency
+            A boolean flag indicating whether to accumulate the efficiency of
+            this surface into
+            :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+            If :obj:`False`, the intensity of the result is meaningless, but
+            the geometry is unchanged and much cheaper to compute, since the
+            efficiency of a multilayer coating usually costs far more than
+            the raytrace it belongs to.
         """
         sag = self.sag
         material = self.material
@@ -141,7 +150,7 @@ class AbstractSurface(
         if transformation is not None:
             rays = transformation.inverse(rays)
 
-        rays_1 = sag.propagate_rays(rays)
+        rays_1 = sag.propagate_rays(rays, efficiency=efficiency)
 
         position_1 = rays_1.position
 
@@ -172,11 +181,14 @@ class AbstractSurface(
             normal=normal,
         )
 
-        efficiency = material.efficiency(rays_1, normal)
-        if rulings is not None:
-            efficiency = efficiency * rulings.efficiency(rays_1, normal)
+        if efficiency:
+            throughput = material.efficiency(rays_1, normal)
+            if rulings is not None:
+                throughput = throughput * rulings.efficiency(rays_1, normal)
+            intensity_2 = intensity_1 * throughput
+        else:
+            intensity_2 = intensity_1
 
-        intensity_2 = intensity_1 * efficiency
         attenuation_2 = material.attenuation(rays_1)
 
         rays_2 = dataclasses.replace(

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -380,9 +380,14 @@ class AbstractSequentialSystem(
         rays_component_variable.y = a.y
         rays_component_variable.z = zfunc(a)
 
+        # only the geometry of these rays is used, and the objective is
+        # evaluated once per iteration of the solver, so the efficiency of
+        # each surface would be by far the most expensive part of finding
+        # the stops and is skipped
         rays = optika.propagators.propagate_rays(
             propagators=subsystem[1:],
             rays=rays,
+            efficiency=False,
         )
 
         transformation_last = subsystem[~0].transformation
@@ -657,6 +662,7 @@ class AbstractSequentialSystem(
         result.outputs = optika.propagators.propagate_rays(
             propagators=subsystem,
             rays=rays_stop.outputs,
+            efficiency=False,
         )
 
         obj = subsystem[~0]
@@ -849,6 +855,7 @@ class AbstractSequentialSystem(
         normalized_field: bool = True,
         normalized_pupil: bool = True,
         accumulate: bool = True,
+        efficiency: bool = True,
     ) -> optika.rays.RayFunctionArray:
         """
         Given the wavelength, field position, and pupil position of some input
@@ -882,6 +889,14 @@ class AbstractSequentialSystem(
             in normalized or physical units.
         accumulate
             Whether to include intermediate rays in the result.
+        efficiency
+            A boolean flag indicating whether to accumulate the efficiency of
+            each surface into
+            :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+            If :obj:`False`, the intensity of the result is meaningless, but
+            the geometry and
+            :attr:`~optika.rays.AbstractRayVectorArray.unvignetted` are
+            unchanged and much cheaper to compute.
 
         See Also
         --------
@@ -921,11 +936,13 @@ class AbstractSequentialSystem(
                 propagators=surfaces,
                 rays=rays,
                 axis=axis,
+                efficiency=efficiency,
             )
         else:
             result.outputs = optika.propagators.propagate_rays(
                 propagators=surfaces,
                 rays=rays,
+                efficiency=efficiency,
             )
 
         return result
@@ -938,6 +955,7 @@ class AbstractSequentialSystem(
         pupil: None | na.AbstractCartesian2dVectorArray = None,
         normalized_field: bool = True,
         normalized_pupil: bool = True,
+        efficiency: bool = True,
     ) -> optika.rays.RayFunctionArray:
         """
         Given the wavelength, field position, and pupil position of some input
@@ -966,6 +984,14 @@ class AbstractSequentialSystem(
         normalized_pupil
             A boolean flag indicating whether the `pupil` parameter is given
             in normalized or physical units.
+        efficiency
+            A boolean flag indicating whether to accumulate the efficiency of
+            each surface into
+            :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+            If :obj:`False`, the intensity of the result is meaningless, but
+            the geometry and
+            :attr:`~optika.rays.AbstractRayVectorArray.unvignetted` are
+            unchanged and much cheaper to compute.
 
         See Also
         --------
@@ -982,6 +1008,7 @@ class AbstractSequentialSystem(
             axis=axis,
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
+            efficiency=efficiency,
         )
         rayfunction = raytrace[{axis: ~0}]
         rays = rayfunction.outputs
@@ -1263,12 +1290,16 @@ class AbstractSequentialSystem(
         degree
             The degree of the polynomial distortion model.
         """
+        # this fit reads only the geometry of the rays and which of them were
+        # vignetted, never their intensity, so the efficiency of each surface
+        # is not computed
         rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
             wavelength=wavelength,
             field=field,
             pupil=pupil,
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
+            efficiency=False,
         )
 
         if not axis_wavelength:
@@ -1349,12 +1380,16 @@ class AbstractSequentialSystem(
         degree
             The degree of the polynomial vignetting model.
         """
+        # this fit reads only the geometry of the rays and which of them were
+        # vignetted, never their intensity, so the efficiency of each surface
+        # is not computed
         rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
             wavelength=wavelength,
             field=field,
             pupil=pupil,
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
+            efficiency=False,
         )
 
         if not axis_wavelength:
@@ -1629,6 +1664,7 @@ class AbstractSequentialSystem(
         pupil: None | na.AbstractCartesian2dVectorArray = None,
         normalized_field: bool = True,
         normalized_pupil: bool = True,
+        efficiency: bool = True,
     ) -> tuple[
         optika.rays.RayFunctionArray,
         tuple[str, ...],
@@ -1661,6 +1697,12 @@ class AbstractSequentialSystem(
         normalized_pupil
             A boolean flag indicating whether the `pupil` parameter is given
             in normalized or physical units.
+        efficiency
+            A boolean flag indicating whether to accumulate the efficiency of
+            each surface into
+            :attr:`~optika.rays.AbstractRayVectorArray.intensity`.
+            Ignored if all of the grids are :obj:`None`, since
+            :attr:`rayfunction_default` is then returned as-is.
         """
         if wavelength is None and field is None and pupil is None:
             rays = self.rayfunction_default
@@ -1674,6 +1716,7 @@ class AbstractSequentialSystem(
                 pupil=pupil,
                 normalized_field=normalized_field,
                 normalized_pupil=normalized_pupil,
+                efficiency=efficiency,
             )
             axis_wavelength = self._normalize_axis_wavelength(
                 axis_wavelength=None,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -233,6 +233,21 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(raytrace.outputs, optika.rays.RayVectorArray)
         assert a.axis_surface not in raytrace.shape
 
+    def test_rayfunction_efficiency(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        """
+        Skipping the efficiency of each surface leaves the geometry of the
+        rays untouched.
+        """
+        expected = a.rayfunction()
+        result = a.rayfunction(efficiency=False)
+
+        assert np.all(result.outputs.position == expected.outputs.position)
+        assert np.all(result.outputs.direction == expected.outputs.direction)
+        assert np.all(result.outputs.unvignetted == expected.outputs.unvignetted)
+
     def test_rayfunction_default(self, a: optika.systems.AbstractSequentialSystem):
         rayfunction = a.rayfunction_default
         assert isinstance(rayfunction, optika.rays.RayFunctionArray)
@@ -555,6 +570,38 @@ _grid_input_wavelength = optika.vectors.ObjectVectorArray(
 )
 class TestSequentialSystem(AbstractTestAbstractSequentialSystem):
     pass
+
+
+@dataclasses.dataclass(eq=False, repr=False)
+class _HalfMirror(optika.materials.Mirror):
+    """A mirror which reflects half of the light which strikes it."""
+
+    def efficiency(
+        self,
+        rays: optika.rays.RayVectorArray,
+        normal: na.AbstractCartesian3dVectorArray,
+    ) -> na.ScalarLike:
+        return 0.5
+
+
+def test_rayfunction_efficiency_skipped():
+    """
+    Skipping the efficiency of each surface leaves the intensity of the rays
+    at its input value, instead of the throughput of the system.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=[dataclasses.replace(_surfaces[0], material=_HalfMirror())],
+        sensor=_sensor,
+        grid_input=_grid_input,
+    )
+
+    expected = system.rayfunction()
+    result = system.rayfunction(efficiency=False)
+
+    assert np.all(expected.outputs.intensity < 1)
+    assert np.all(result.outputs.intensity == 1)
+    assert np.all(result.outputs.position == expected.outputs.position)
+    assert np.all(result.outputs.unvignetted == expected.outputs.unvignetted)
 
 
 def test__anchor_surface():


### PR DESCRIPTION
`Surface.propagate_rays` folds the efficiency of the surface material and its rulings into the intensity of the rays. For a system with multilayer coatings that is not a detail of the raytrace, it is nearly all of it. Tracing the ESIS design over nine wavelengths:

```
rayfunction (as-is)                3.704 s
rayfunction (efficiency stubbed)   0.447 s
```

The efficiency reaches only `intensity`. It never touches the position, the direction, or the `unvignetted` mask, which is set entirely by the apertures. So a caller asking a purely geometric question pays for a result it throws away, and three of them live in this package:

- `_ray_error`, the objective of the root-finder which locates the stops, evaluated once per iteration of the solver
- `distortion`, which reads the ray positions and the vignetting mask
- `vignetting`, which reads only the vignetting mask

This adds an `efficiency` flag to `propagate_rays` and `accumulate_rays`, to `AbstractRayPropagator.propagate_rays` and its two implementations, and to `raytrace` and `rayfunction`, then passes `efficiency=False` from those three call sites.

## Effect

```
stop solve with efficiency     0.439 s
stop solve without efficiency  0.147 s   (2.98x)

linearize (before)   11.31 s
linearize (after)     4.64 s   (2.44x)
```

`linearize` benefits because it calls all three.

## Nothing changes

Every quantity these methods produce was compared against `main` in a worktree, on `esis.flights.f1.optics.design_single()` over nine wavelengths. All 57 arrays are equal bit for bit:

```
stops          6 arrays   IDENTICAL     # position and direction of the stop rayfunction
grid           4 arrays   IDENTICAL     # the denormalized field and pupil
field_min/max  4 arrays   IDENTICAL
pupil_min/max  4 arrays   IDENTICAL
rays           8 arrays   IDENTICAL     # a full-efficiency trace, intensity included
distortion    20 arrays   IDENTICAL
vignetting    10 arrays   IDENTICAL
area           1 arrays   IDENTICAL
```

## Tests

`test_rayfunction_efficiency` asserts the geometry is untouched across every parametrized system. Since all of those use a perfect mirror and would leave the intensity at one either way, `test_rayfunction_efficiency_skipped` builds a system with a half-reflecting mirror, where the intensity is `0.5` with the flag on and `1` with it off.

Full suite passes (17723 passed, 296 skipped, 17 xfailed). The four changed modules are at 100% line coverage.

## Follow-ups, not in this PR

- `distortion` and `vignetting` still trace separately, with identical arguments. Sharing one trace is worth a further 7% now that the traces are cheap, and is really a duplication cleanup.
- `linearize` takes `direction` from `rayfunction_default`, which is on the *default* wavelength grid rather than the one it was asked to linearize on. That looks wrong, but fixing it changes the value, so it needs its own discussion.
- `area_effective` averages over every field sample including those entirely outside the field stop, while `vignetting` normalizes over only the unvignetted ones. `LinearSystem` multiplies the two. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
