### PR TITLE
Let the rays be hidden by the optics they pass behind

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1778,7 +1778,13 @@ class AbstractSequentialSystem(
             if unit is not None:
                 position = position.to(unit)
 
-            result["rays"] = na.plt.plot(
+            # On a 3D axes the rays are drawn as collections, which the axes
+            # sorts into the scene by depth. A line is not sorted at all: it
+            # keeps the zorder it was given, which puts it either in front of
+            # every optic or, at the default, behind all of them.
+            plot = na.plt.line_collection if optika.plot.is_3d(ax) else na.plt.plot
+
+            result["rays"] = plot(
                 position,
                 ax=ax,
                 axis=self.axis_surface,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1,5 +1,7 @@
 import dataclasses
+import matplotlib.lines
 import matplotlib.pyplot as plt
+import mpl_toolkits.mplot3d.art3d
 import pytest
 import numpy as np
 import astropy.units as u
@@ -860,3 +862,50 @@ def test_stops_afocal():
 
     assert float(na.value(direction).ndarray) == pytest.approx(0.05)
     assert float(na.value(position.to(u.mm)).ndarray) == pytest.approx(1)
+
+
+def test_plot_rays_3d_is_a_collection():
+    """
+    On a 3D axes the rays are drawn as collections, one per segment.
+
+    A line is not sorted into a 3D scene at all: it keeps the zorder it was
+    given, and at the default that is below every filled surface, so a beam
+    disappears behind the first optic it crosses instead of reaching it.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+
+    result = _system_newtonian.plot(
+        ax=ax,
+        components=("z", "x", "y"),
+        plot_rays=True,
+    )
+
+    rays = [a for a in np.atleast_1d(result["rays"].ndarray).flat if a is not None]
+    plt.close(fig)
+
+    assert rays
+    for artist in rays:
+        assert isinstance(artist, mpl_toolkits.mplot3d.art3d.Line3DCollection)
+
+    # a segment for every gap between surfaces
+    axis = _system_newtonian.axis_surface
+    assert na.shape(result["rays"])[axis] == len(_system_newtonian.surfaces_all) - 1
+
+
+def test_plot_rays_2d_is_a_line():
+    """On a 2D axes the rays are still drawn as ordinary lines."""
+    fig, ax = plt.subplots()
+
+    result = _system_newtonian.plot(
+        ax=ax,
+        components=("z", "x"),
+        plot_rays=True,
+    )
+
+    rays = [a for a in np.atleast_1d(result["rays"].ndarray).flat if a is not None]
+    plt.close(fig)
+
+    assert rays
+    for artist in rays:
+        assert isinstance(artist, matplotlib.lines.Line2D)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy!=6.1.5",
-    "named-arrays~=2.5",
+    "named-arrays~=2.7",
     "pymupdf",
     "joblib",
     "ezdxf",


### PR DESCRIPTION
A ray drawn on a 3D axes is a line, and a 3D axes sorts only its collections and
patches (`axes3d.py:434-437`). A line keeps whatever zorder it was given — at the
default, 2, which is below the 3.5-and-up handed to the sorted collections. So a
beam vanished behind the first optic it crossed instead of reaching it.

In the ESIS layout the light stopped dead at the edge of the primary and at the
edge of each detector, rather than landing on them:

| before | after |
|---|---|
| beam cut off at the detector's edge | beam reaches the detector's face |

Drawn with `na.plt.line_collection` (sun-data/named-arrays#222) the rays are
sorted into the scene along with the optics, a segment at a time, so a beam is
hidden exactly where an optic is in front of it and drawn everywhere else.

```python
plot = na.plt.line_collection if optika.plot.is_3d(ax) else na.plt.plot
result["rays"] = plot(position, axis=self.axis_surface, ...)
```

Only on a 3D axes. Seen flat there is nothing to be hidden by and a line is the
better artist, so a 2D plot is unchanged — the returned artists are still
`Line2D` there.

## Granularity

One collection per segment rather than per ray. That is not incidental: a
collection is sorted by a single depth, so one holding a whole ray gets one
number for a path spanning the instrument. Measured on the ESIS layout, per-ray
collections paint four rays straight over the edge of the primary at `azim=40`,
while per-segment is pixel-identical to grouping the segments by hand at every
view angle tried. `line_collection` does the segmenting.

## Testing

Two tests: that the rays come back as `Line3DCollection` on a 3D axes with one
segment per gap between surfaces, and as `Line2D` on a 2D one. 589 tests pass
across `optika/systems` and `optika/_tests`.

## Dependency

Requires `named-arrays~=2.7`, released today.

Stacked on #202, which supplies `optika.plot.is_3d` and the filled surfaces that
make the occlusion visible in the first place. Base will retarget to `main` when
that merges.
