### PR TITLE
Average the effective area over the field of view, not past it

### DIFF
--- a/optika/radiometry/_vignetting.py
+++ b/optika/radiometry/_vignetting.py
@@ -25,7 +25,8 @@ class AbstractVignettingModel(
     """
     An interface describing an arbitrary vignetting model, which maps scene
     coordinates to the relative illumination of the optical system (the spatial
-    response normalized to one at the center of the field of view).
+    response normalized to one *on average* over the field of view, not at its
+    center).
     """
 
     @abc.abstractmethod

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1441,9 +1441,15 @@ class AbstractSequentialSystem(
         efficiency, and the absorbance of the sensor) is weighted by the area
         of its pupil cell and summed, giving the effective area at that field
         position. Rays blocked by an aperture are excluded from the sum. The
-        result is then averaged over the field of view and returned as an
-        :class:`~optika.radiometry.InterpolatedEffectiveAreaModel`, which
-        linearly interpolates in wavelength.
+        result is then averaged over the field of view, counting only those
+        field positions which have at least one unvignetted ray, and returned
+        as an :class:`~optika.radiometry.InterpolatedEffectiveAreaModel`,
+        which linearly interpolates in wavelength.
+
+        The average is taken over the same field positions that
+        :meth:`vignetting` normalizes its illumination over, so that the two
+        models can be multiplied together to recover the effective area at a
+        given field position.
 
         The components of `pupil` are interpreted as the vertices of a grid of
         cells, and the rays are traced at the corresponding cell centers, so
@@ -1554,12 +1560,25 @@ class AbstractSequentialSystem(
             normalized_pupil=False,
         )
 
+        unvignetted = rays.outputs.unvignetted
+
         area_eff = rays.outputs.intensity.sum(
             axis=axis_pupil,
-            where=rays.outputs.unvignetted,
+            where=unvignetted,
         )
 
-        area_eff = area_eff.mean(axis_field)
+        # Field positions with no unvignetted rays lie outside the field of
+        # view and are excluded, exactly as :meth:`vignetting` excludes them
+        # when it normalizes its illumination.  The two are multiplied
+        # together by :class:`~optika.systems.LinearSystem`, so an average
+        # taken over a different set of field positions than the vignetting
+        # model is normalized over would rescale the result by the ratio of
+        # the two sets.
+        area_eff = np.mean(
+            area_eff,
+            axis=axis_field,
+            where=unvignetted.any(axis_pupil),
+        )
 
         return optika.radiometry.InterpolatedEffectiveAreaModel(
             wavelength=wavelength,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -604,6 +604,45 @@ def test_rayfunction_efficiency_skipped():
     assert np.all(result.outputs.unvignetted == expected.outputs.unvignetted)
 
 
+def test_area_effective_ignores_field_outside_the_field_of_view():
+    """
+    The effective area is averaged over the field of view, so sampling more
+    of the field which lies outside it does not change the answer.
+
+    This is what lets the model be multiplied by the vignetting model, which
+    normalizes its illumination over that same set of field positions.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=_surfaces,
+        sensor=_sensor,
+        grid_input=_grid_input_wavelength,
+    )
+
+    field = na.Cartesian2dVectorLinearSpace(
+        start=0,
+        stop=1,
+        axis=na.Cartesian2dVectorArray("field_x", "field_y"),
+        num=5,
+    )
+
+    # the same five samples along each axis, plus two which land far enough
+    # outside the field stop that no ray through them reaches the sensor
+    samples = np.array([-3, 0, 0.25, 0.5, 0.75, 1, 3])
+    field_extended = na.Cartesian2dVectorArray(
+        x=na.ScalarArray(samples, axes="field_x"),
+        y=na.ScalarArray(samples, axes="field_y"),
+    )
+
+    result = system.area_effective(field=field)
+    result_extended = system.area_effective(field=field_extended)
+
+    # `area_effective` traces at randomly placed cell centers, so two calls
+    # differ by a percent or so.  Averaging over the extra field positions
+    # instead of ignoring them would halve the result, which this separates
+    # comfortably.
+    assert np.allclose(result_extended.area, result.area, rtol=0.05)
+
+
 def test__anchor_surface():
     first = optika.surfaces.Surface(name="first")
     last = optika.surfaces.Surface(name="last")


### PR DESCRIPTION
`area_effective` ends with a bare `area_eff.mean(axis_field)`, which averages over every field position in the grid, including the ones entirely outside the field stop that contribute zero. Three lines up, `vignetting` does the opposite, normalizing its illumination with `where=unvignetted.any(axis_pupil)`.

`LinearSystem` multiplies the two ([_linear.py:251](https://github.com/sun-data/optika/blob/main/optika/systems/_linear.py#L251)), and the product only reconstructs the effective area at a field position if both factors are taken over the same set of positions.

## Why any average works, as long as it is the same one

Writing `a` for the per-field effective area and `v` for the unvignetted fraction, `a = k(λ)·v` to within a quarter of a percent:

```
  wavelength 0:  a/v over 77 illuminated field points   spread=1.01x   std/mean=0.21%
  wavelength 1:  a/v over 77 illuminated field points   spread=1.01x   std/mean=0.25%
  wavelength 2:  a/v over 61 illuminated field points   spread=1.00x   std/mean=0.10%
```

So for any field functional `L`, the product `L[a]·v/L[v]` equals `a` exactly. Mean, masked mean, center, max: all correct, provided both factors use the same one. They didn't, and the product came out low by the illuminated fraction of whichever field grid was used.

## Effect

The illuminated fraction varies with wavelength, so this was not a constant scale error. The spectral shape was wrong too:

```
wavelength (AA): [580. 588. 595. 602. 610. 618. 625. 632. 640.]
before         : [0.3696 0.655  0.781  0.8851 1.0149 1.1603 1.2811 1.4027 1.3452]
after          : [0.688  0.8615 0.9742 1.1041 1.266  1.4473 1.5981 1.7498 1.9149]
after / before : [1.862  1.315  1.247  1.247  1.247  1.247  1.247  1.247  1.424]
```

No constant calibration factor could have absorbed that, and the band edges were worst.

The result also stops depending on how much empty field was sampled:

```
             before                      after
  5x5    0.29 ->                    0.6845
 11x11   0.49 ->                    0.6785
 21x21   0.67 / 0.77 ->             0.6787
```

## Averaging vs normalizing at the center

Reconsidered here, and the average is kept. The center is a single field position, so it inherits the entire pupil-jitter noise from the `random=True` cell centers, with no other samples to average against. Eight draws on an 11×11 field:

```
  centre         mean=1.0359  std/mean=6.42%  ptp/mean=21.45%
  masked_mean    mean=1.0334  std/mean=0.69%  ptp/mean= 2.44%
```

Nine times noisier. The jitter and the average belong together. (An illumination-weighted average with no hard mask was also tried: same noise, slightly worse field convergence, so not worth the complexity.)

`AbstractVignettingModel` still described its illumination as "normalized to one at the center of the field of view", which is how #159 described it before #184 implemented the average. Updated to say what the code does.

## Tests

`test_area_effective_ignores_field_outside_the_field_of_view` extends a field grid with samples far outside the field stop and asserts the effective area is unchanged. Verified to fail on `main`, where the extra dark samples halve the result (ratio 0.51 against 1.0000 with the fix). The tolerance is `rtol=0.05` because `area_effective` traces at randomly placed cell centers, so repeated calls differ by about a percent.

Full suite passes: 17740 passed, 304 skipped, 17 xfailed.

## Not in this PR

The remaining problems are in the pupil, not the field, and are independent of this one:

- `linearize` hands the two models different pupil grids, so their `v` disagrees by up to 31% even at 90-100% of peak illumination. It is coarse-grid quantization: ~30 unvignetted samples out of ~100 pins `v` to only about ±10% per field position.
- The pupil quadrature does not settle. Effective area at field center by pupil cells: 1.294 at 4×4, 1.445 at 10×10, 1.497 at 20×20, 1.497 at 40×40, 1.449 at 80×80. A square grid over a round stop with cells counted whole or not at all, so O(1/N) with oscillating sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
