### PR TITLE
Check that linearizing a system conserves flux

### DIFF
--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -645,6 +645,110 @@ def test_area_effective_ignores_field_outside_the_field_of_view():
     assert np.allclose(result_extended.area, result.area, rtol=0.05)
 
 
+def _system_vignetted() -> optika.systems.SequentialSystem:
+    """
+    A system whose field stop is a circle rather than the sensor.
+
+    The normalized field grid is the bounding box of the field of view, so a
+    field stop shaped like the sensor fills it and nothing is vignetted.  A
+    round one leaves the corners dark, which is what a system like ESIS
+    actually looks like and what makes the vignetting model do any work.
+    """
+    surfaces = [
+        optika.surfaces.Surface(
+            name="mirror",
+            sag=optika.sags.SphericalSag(-200 * u.mm),
+            material=optika.materials.Mirror(),
+            aperture=optika.apertures.CircularAperture(20 * u.mm),
+            is_pupil_stop=True,
+            transformation=na.transformations.Cartesian3dTranslation(z=100 * u.mm),
+        ),
+        optika.surfaces.Surface(
+            name="field stop",
+            aperture=optika.apertures.CircularAperture(0.96 * u.mm),
+            is_field_stop=True,
+            transformation=na.transformations.Cartesian3dTranslation(z=2 * u.mm),
+        ),
+    ]
+    sensor = optika.sensors.ImagingSensor(
+        name="sensor",
+        width_pixel=15 * u.um,
+        axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
+        timedelta_exposure=1 * u.s,
+        num_pixel=na.Cartesian2dVectorArray(128, 128),
+        transformation=na.transformations.Cartesian3dTranslation(z=1 * u.mm),
+    )
+    grid = optika.vectors.ObjectVectorArray(
+        wavelength=na.linspace(500, 600, axis="wavelength", num=3) * u.nm,
+        field=na.Cartesian2dVectorLinearSpace(
+            start=-1,
+            stop=1,
+            axis=na.Cartesian2dVectorArray("field_x", "field_y"),
+            num=11,
+        ),
+        pupil=na.Cartesian2dVectorLinearSpace(
+            start=-1,
+            stop=1,
+            axis=na.Cartesian2dVectorArray("pupil_x", "pupil_y"),
+            num=11,
+        ),
+    )
+    return optika.systems.SequentialSystem(
+        surfaces=surfaces,
+        sensor=sensor,
+        grid_input=grid,
+    )
+
+
+def test_linearize_conserves_flux():
+    """
+    A flat field through the linearized system collects the same number of
+    electrons as the same flat field traced through the system it came from.
+
+    This is the end-to-end statement of what `linearize` is for, and the one
+    thing that exercises the distortion, vignetting, and effective-area
+    models against each other rather than one at a time.
+    """
+    system = _system_vignetted()
+
+    # a uniform scene covering the inner half of the field of view, kept away
+    # from the edge where the polynomial vignetting model cannot follow the
+    # hard cutoff of the field stop
+    center = (system.field_max + system.field_min) / 2
+    half = (system.field_max - system.field_min) / 4
+    num = 12
+    scene = na.FunctionArray(
+        inputs=na.SpectralPositionalVectorArray(
+            wavelength=na.linspace(500, 600, axis="wavelength", num=4) * u.nm,
+            position=na.Cartesian2dVectorArray(
+                x=na.linspace(
+                    center.x - half.x, center.x + half.x, axis="field_x", num=num + 1
+                ),
+                y=na.linspace(
+                    center.y - half.y, center.y + half.y, axis="field_y", num=num + 1
+                ),
+            ),
+        ),
+        outputs=1e3
+        * u.photon
+        / u.s
+        / u.cm**2
+        / u.arcsec**2
+        / u.nm
+        * na.ScalarArray(np.ones((num, num)), axes=("field_x", "field_y")),
+    )
+
+    expected = system.image(scene, noise=False).outputs.sum()
+    result = system.linearize(degree=2).image(scene, noise=False).outputs.sum()
+
+    # the two discretize the problem differently, and `area_effective` traces
+    # at randomly placed pupil cell centers, so they agree to a few percent
+    # rather than exactly.  An average of the effective area taken over a
+    # different set of field positions than the vignetting model is
+    # normalized over would put this near 0.56, which the tolerance excludes.
+    assert np.allclose(result, expected, rtol=0.15)
+
+
 def test__anchor_surface():
     first = optika.surfaces.Surface(name="first")
     last = optika.surfaces.Surface(name="last")


### PR DESCRIPTION
**Depends on #207, and must merge after it** (the test fails without that fix).

This targets `main` rather than #207's branch on purpose, so that deleting that branch on merge cannot close this PR. Until #207 lands, the diff below shows both changes; once it does, this branch is rebased and the diff narrows to the test alone.

## Why

Nothing tied `SequentialSystem` and the `LinearSystem` it produces together:

- `test_linearize` asserts the types of the three fitted models and nothing about their values
- `_linear_test.py` builds its systems from hand-written `_distortion()` / `_vignetting()` / `_area_effective()` fixtures, never from a real system
- `test_image` asserts each system puts a nonzero number of electrons on its sensor

So the distortion, vignetting, and effective-area models were each checked alone and never against each other, which is how #207's bug survived: it is entirely a disagreement *between* two of them.

## The test

Trace a flat field through a system and through its linearization; compare total electrons.

The interesting part is that the system has to be chosen carefully. The normalized field grid is the bounding box of the field of view, so a field stop shaped like the sensor fills that box and leaves nothing vignetted. On the system the other tests use, 99% of the grid is illuminated, the vignetting model has no work to do, and **the test would pass with or without #207**. A round field stop leaves the corners dark, which is the shape ESIS actually has:

```
  radius  0.96 mm: illuminated fraction = 0.5702
```

With that, on a scene covering the inner half of the field of view:

```
 scene FOV |   sequential |       linear |     now |  before #207
       0.5 |    8.523e+12 |    8.404e+12 |  0.9860 |  0.5622
       0.8 |    1.381e+13 |    1.465e+13 |  1.0606 |  0.6048
       1.0 |    1.583e+13 |     1.47e+13 |  0.9286 |  0.5295
```

## Tolerance

`rtol=0.15`. The two discretize differently and `area_effective` traces at randomly placed pupil cell centers, so exact agreement isn't available. Measured spread over six rebuilds of the linear system:

```
   [1.015  1.0169 1.0099 1.0167 1.0133 1.013 ]
   mean 1.0141  std 0.0024  min 1.0099  max 1.0169
```

Verified to fail with #207's change reverted. Runs in 0.75 s. Five consecutive runs pass.

## Found while writing this, not addressed here

**The polynomial fits are unusable above degree 2 and fail silently.** Fitted illumination over the scene, on an 11×11 field grid with 3 wavelengths:

```
 field  deg | linear/seq | illumination over the scene
    11    2 |     1.0685 | min=    1.034  max=     1.654  mean=    1.412
    11    3 |     0.3554 | min=-3.07e+13  max= 3.07e+13   mean=    1.404
    21    4 |     9.3235 | min=-2.01e+14  max=-7.39e+12   mean=-1.04e+14
```

Almost certainly rank deficiency: a degree-3 fit needs at least 4 samples along the wavelength axis and the grid has 3. It produces no error and no warning, just ±10¹⁴ and negative illumination. Worth its own issue, and a reason this test pins `degree=2`.

**`_grid_input` in this module spans [0, 1]**, one quadrant of the normalized field, rather than [-1, 1]. Fitting there and evaluating over the full field of view gave 0.58 of the true flux. Presumably deliberate for the other tests, but it makes anything built on `linearize` misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

