### PR TITLE
Let a system show the outline of its field, not only the corners

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -708,28 +708,62 @@ class AbstractSequentialSystem(
         )
 
     @property
+    def _axis_stops(self) -> tuple[str, str]:
+        """The logical axes along the edges of the two stop surfaces."""
+        return (self._axis_field_stop, self._axis_pupil_stop)
+
+    @property
+    def field_boundary(self) -> na.AbstractCartesian2dVectorArray:
+        """
+        The field coordinates at the edge of this optical system's field of view.
+
+        These are the rays which graze the edges of both stops, so they trace
+        the outline of the field rather than filling it. In angle if the object
+        is at infinity, and in position if it is not.
+
+        How wide a field of view this outline represents is a question the
+        outline alone does not answer, and different instruments answer it
+        differently. For a field stop which is not a circle, the extent of the
+        field depends on the direction it is measured along, and on how the
+        system is rolled about its optical axis. An octagonal stop, for
+        instance, is wider corner to corner than edge to edge by a factor of
+        :math:`1 / \\cos(22.5^\\circ)`. Reduce this outline in whichever way
+        the instrument at hand takes to be its field of view;
+        :attr:`field_min` and :attr:`field_max` are two such reductions.
+        """
+        rays = self.rayfunction_stops.outputs
+        if self.object_is_at_infinity:
+            return optika.angles(rays.direction)
+        else:
+            return rays.position.xy
+
+    @property
+    def pupil_boundary(self) -> na.AbstractCartesian2dVectorArray:
+        """
+        The coordinates at the edge of this optical system's entrance pupil.
+
+        The counterpart of :attr:`field_boundary`, in position if the object is
+        at infinity and in angle if it is not.
+        """
+        rays = self.rayfunction_stops.outputs
+        if self.object_is_at_infinity:
+            return rays.position.xy
+        else:
+            return optika.angles(rays.direction)
+
+    @property
     def field_min(self) -> na.AbstractCartesian2dVectorArray:
         """
         The lower left corner of this optical system's field of view.
         """
-        axis = (self._axis_field_stop, self._axis_pupil_stop)
-        if self.object_is_at_infinity:
-            angles = optika.angles(self.rayfunction_stops.outputs.direction)
-            return angles.min(axis)
-        else:
-            return self.rayfunction_stops.outputs.position.xy.min(axis)
+        return self.field_boundary.min(self._axis_stops)
 
     @property
     def field_max(self) -> na.AbstractCartesian2dVectorArray:
         """
         The upper right corner of this optical system's field of view.
         """
-        axis = (self._axis_field_stop, self._axis_pupil_stop)
-        if self.object_is_at_infinity:
-            angles = optika.angles(self.rayfunction_stops.outputs.direction)
-            return angles.max(axis)
-        else:
-            return self.rayfunction_stops.outputs.position.xy.max(axis)
+        return self.field_boundary.max(self._axis_stops)
 
     @property
     def pupil_min(self) -> na.AbstractCartesian2dVectorArray:
@@ -737,12 +771,7 @@ class AbstractSequentialSystem(
         The lower left corner of this optical system's entrance pupil in
         physical units.
         """
-        axis = (self._axis_field_stop, self._axis_pupil_stop)
-        if self.object_is_at_infinity:
-            return self.rayfunction_stops.outputs.position.xy.min(axis)
-        else:
-            angles = optika.angles(self.rayfunction_stops.outputs.direction)
-            return angles.min(axis)
+        return self.pupil_boundary.min(self._axis_stops)
 
     @property
     def pupil_max(self):
@@ -750,12 +779,7 @@ class AbstractSequentialSystem(
         The upper right corner of this optical system's entrance pupil in
         physical units.
         """
-        axis = (self._axis_field_stop, self._axis_pupil_stop)
-        if self.object_is_at_infinity:
-            return self.rayfunction_stops.outputs.position.xy.max(axis)
-        else:
-            angles = optika.angles(self.rayfunction_stops.outputs.direction)
-            return angles.max(axis)
+        return self.pupil_boundary.max(self._axis_stops)
 
     def _denormalize_grid(
         self,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -113,9 +113,35 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result.outputs, optika.rays.RayVectorArray)
         assert result.ndim >= 2
 
+    def test_field_boundary(self, a: optika.systems.AbstractSequentialSystem):
+        result = a.field_boundary
+        assert isinstance(result, na.AbstractCartesian2dVectorArray)
+
+        # the outline of the field, along the edge of each stop
+        assert set(a._axis_stops).issubset(na.shape(result))
+
+        if a.object_is_at_infinity:
+            assert na.unit(result).is_equivalent(u.deg)
+        else:
+            assert na.unit(result).is_equivalent(u.m)
+
+    def test_pupil_boundary(self, a: optika.systems.AbstractSequentialSystem):
+        result = a.pupil_boundary
+        assert isinstance(result, na.AbstractCartesian2dVectorArray)
+        assert set(a._axis_stops).issubset(na.shape(result))
+
+        if a.object_is_at_infinity:
+            assert na.unit(result).is_equivalent(u.m)
+        else:
+            assert na.unit(result).is_equivalent(u.deg)
+
     def test_field_min(self, a: optika.systems.AbstractSequentialSystem):
         result = a.field_min
         assert isinstance(result, na.AbstractCartesian2dVectorArray)
+
+        # the corner of the field is a reduction of its outline
+        assert np.all(result == a.field_boundary.min(a._axis_stops))
+
         if a.object_is_at_infinity:
             assert na.unit(result).is_equivalent(u.deg)
         else:


### PR DESCRIPTION
`field_min` and `field_max` give the corners of the box which encloses the
field. For a circular or rectangular stop that box *is* the field. For any other
shape it is not, and the box reports a number which depends on how the system
happens to be rolled about its optical axis.

Measuring one instrument through two of its own channels shows the problem:

```
                           bbox              min width   max width
design_single              11.552 x 11.558     11.552      12.509
design().isel(channel=0)   12.505 x 12.509     11.552      12.509
design().isel(channel=1)   12.509 x 12.505     11.552      12.509
```

The bounding box swings by 8% and even swaps its x and y between channels, while
the width of the field measured across it does not move. The 8% is exactly
`1 / cos(22.5 deg)`: the stop is a regular octagon, and the box is reporting
corner to corner in one roll and edge to edge in another.

Which of those is "the field of view" is a question about the instrument, not
about the optics. So this does not choose. A system now exposes the outline
itself and leaves the reduction to whoever owns the convention:

```python
system.field_boundary   # the field coordinates at the edge of the field
system.pupil_boundary   # its counterpart at the entrance pupil
```

Angles if the object is at infinity, positions if it is not, as the existing
corner properties already were.

## The corners become reductions

All four of `field_min`, `field_max`, `pupil_min` and `pupil_max` were the same
few lines four times over: take `rayfunction_stops.outputs`, choose angle or
position by `object_is_at_infinity`, reduce over the two stop axes. They are now
one line each over the appropriate boundary, and the repeated axis tuple is a
private `_axis_stops`.

No behaviour changes. Verified against ESIS, where `field_max - field_min` gives
11.5515 arcmin before and after.

## Testing

`test_field_boundary` and `test_pupil_boundary` check the type, the units under
both object distances, and that the outline carries both stop axes.
`test_field_min` additionally asserts it equals the reduction of the boundary,
so the two cannot drift apart.

524 tests pass in `optika/systems`; `_sequential.py` stays at 100% coverage.
