### PR TITLE
Let a multilayer stack be interpolated over the angle of incidence

### DIFF
--- a/optika/materials/_multilayers.py
+++ b/optika/materials/_multilayers.py
@@ -768,6 +768,10 @@ def layer_absorbance(
     return flux_absorbed
 
 
+_axis_interpolation = "_incidence"
+"""The logical axis of the angle-of-incidence interpolation table."""
+
+
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractMultilayerMaterial(
     AbstractMaterial,
@@ -789,6 +793,38 @@ class AbstractMultilayerMaterial(
         return result
 
     @property
+    @abc.abstractmethod
+    def num_interpolation(self) -> None | int:
+        """
+        The number of nodes used to interpolate the response of this stack
+        over the angle of incidence.
+
+        Solving the transfer matrices of a multilayer stack usually costs far
+        more than the raytrace it belongs to, and the result is a smooth
+        function of the angle of incidence, over which a given surface
+        typically spans only a few degrees.  Setting this to an integer
+        evaluates the stack at that many angles spanning the range the rays
+        actually cover, and interpolates the rest, which is much cheaper
+        whenever there are more rays than nodes.
+
+        If :obj:`None` (the default), the stack is solved for every ray.
+
+        The error this introduces grows with the angular range the rays span,
+        measured against the width of the features in the response.  A
+        near-normal system whose surfaces each span a few degrees is
+        reproduced to one part in :math:`10^5` by a handful of nodes, while a
+        stack with a Bragg resonance sampled across tens of degrees needs many
+        more.  Since the nodes cost almost nothing next to the rays, prefer
+        more of them than seems necessary, and check a new system against
+        :obj:`None` before trusting it.
+        """
+
+    @property
+    def _substrate(self) -> None | Layer:
+        """The layer supporting this stack, if it has one."""
+        return None
+
+    @property
     def transformation(self) -> None:
         return None
 
@@ -803,6 +839,89 @@ class AbstractMultilayerMaterial(
         rays: optika.rays.RayVectorArray,
     ) -> na.ScalarLike:
         return rays.attenuation
+
+    def _efficiency(
+        self,
+        rays: optika.rays.RayVectorArray,
+        normal: na.AbstractCartesian3dVectorArray,
+    ) -> tuple[na.ScalarLike, na.ScalarLike]:
+        """
+        The reflectivity and transmissivity of this stack for the given rays,
+        averaged over polarization state.
+
+        Nothing in this package tracks polarization yet, so the two states are
+        averaged as early as possible: the table below is averaged before it
+        is interpolated rather than after, which halves the interpolation and
+        gives the same answer, since interpolation is linear.
+
+        To return the two states separately, drop the two calls to
+        :attr:`~optika.vectors.AbstractPolarizationVectorArray.average` here
+        and interpolate ``.s`` and ``.p`` on their own.  The angle of
+        incidence is still the only variable worth tabulating: what
+        polarization adds is a rotation into the plane of incidence, which
+        varies over the pupil but costs almost nothing next to the stack.
+        Note that a table accurate for the average is not automatically
+        accurate for the two states, and that :func:`multilayer_efficiency`
+        has already discarded the phase, which a coherent treatment needs.
+
+        Parameters
+        ----------
+        rays
+            The rays striking this stack.
+        normal
+            The vector normal to the interface between successive layers.
+        """
+        wavelength = rays.wavelength
+        k = rays.attenuation * wavelength / (4 * np.pi)
+        n = rays.index_refraction + k * 1j
+        direction = -rays.direction @ normal
+
+        kwargs = dict(
+            wavelength=wavelength,
+            n=n,
+            layers=self.layers,
+            substrate=self._substrate,
+        )
+
+        def exact() -> tuple[na.ScalarLike, na.ScalarLike]:
+            r, t = multilayer_efficiency(direction=direction, **kwargs)
+            return r.average, t.average
+
+        num = self.num_interpolation
+        if num is None:
+            return exact()
+
+        # the table is built along the axes which only the angle of incidence
+        # varies over, so the wavelength, the index of refraction of the
+        # ambient medium, and any axis of the stack itself are kept
+        shape_kept = na.broadcast_shapes(
+            na.shape(wavelength),
+            na.shape(n),
+            self.shape,
+        )
+        axis = tuple(a for a in na.shape(direction) if a not in shape_kept)
+        if not axis:
+            return exact()
+
+        nodes = na.linspace(
+            start=direction.min(axis),
+            stop=direction.max(axis),
+            axis=_axis_interpolation,
+            num=num,
+        )
+
+        reflectivity, transmissivity = multilayer_efficiency(
+            direction=nodes,
+            **kwargs,
+        )
+
+        def interpolate(table: na.ScalarLike) -> na.ScalarLike:
+            return na.interp(direction, nodes, table, axis=_axis_interpolation)
+
+        return (
+            interpolate(reflectivity.average),
+            interpolate(transmissivity.average),
+        )
 
     @abc.abstractmethod
     def plot_layers(
@@ -852,18 +971,8 @@ class AbstractMultilayerFilm(
         normal
             the vector normal to the interface between successive layers
         """
-        wavelength = rays.wavelength
-        k = rays.attenuation * wavelength / (4 * np.pi)
-        n = rays.index_refraction + k * 1j
-
-        reflectivity, transmissivity = multilayer_efficiency(
-            wavelength=wavelength,
-            direction=-rays.direction @ normal,
-            n=n,
-            layers=self.layers,
-            substrate=None,
-        )
-        return transmissivity.average
+        reflectivity, transmissivity = self._efficiency(rays, normal)
+        return transmissivity
 
     def plot_layers(
         self,
@@ -887,6 +996,13 @@ class MultilayerFilm(
     layers: None | AbstractLayer | Sequence[AbstractLayer] = None
     """A sequence of layers representing the multilayer stack."""
 
+    num_interpolation: None | int = None
+    """
+    The number of nodes used to interpolate the response of this stack over
+    the angle of incidence, or :obj:`None` to solve it for every ray.
+    See :attr:`~optika.materials.AbstractMultilayerMaterial.num_interpolation`.
+    """
+
     @property
     def shape(self) -> dict[str, int]:
         try:
@@ -905,6 +1021,10 @@ class AbstractMultilayerMirror(
 ):
     """A generalized multilayer mirror coating."""
 
+    @property
+    def _substrate(self) -> None | Layer:
+        return self.substrate
+
     def efficiency(
         self,
         rays: optika.rays.RayVectorArray,
@@ -921,18 +1041,8 @@ class AbstractMultilayerMirror(
         normal
             the vector normal to the interface between successive layers
         """
-        wavelength = rays.wavelength
-        k = rays.attenuation * wavelength / (4 * np.pi)
-        n = rays.index_refraction + k * 1j
-
-        reflectivity, transmissivity = multilayer_efficiency(
-            wavelength=wavelength,
-            direction=-rays.direction @ normal,
-            n=n,
-            layers=self.layers,
-            substrate=self.substrate,
-        )
-        return reflectivity.average
+        reflectivity, transmissivity = self._efficiency(rays, normal)
+        return reflectivity
 
     def plot_layers(
         self,
@@ -1107,6 +1217,13 @@ class MultilayerMirror(
 
     substrate: None | Layer = None
     """A layer representing the substrate that the layers are deposited onto."""
+
+    num_interpolation: None | int = None
+    """
+    The number of nodes used to interpolate the response of this stack over
+    the angle of incidence, or :obj:`None` to solve it for every ray.
+    See :attr:`~optika.materials.AbstractMultilayerMaterial.num_interpolation`.
+    """
 
     @property
     def shape(self) -> dict[str, int]:

--- a/optika/materials/_tests/test_multilayers.py
+++ b/optika/materials/_tests/test_multilayers.py
@@ -1,4 +1,5 @@
 from typing import Sequence
+import dataclasses
 import pytest
 import pathlib
 import numpy as np
@@ -290,6 +291,64 @@ def test_multilayer_efficiency_vs_file(
 class AbstractTestAbstractMultilayerMaterial(
     test_materials.AbstractTestAbstractMaterial,
 ):
+    def test_num_interpolation(self, a: optika.materials.AbstractMultilayerMaterial):
+        result = a.num_interpolation
+        assert (result is None) or (result > 0)
+
+    def test_efficiency_interpolated(
+        self,
+        a: optika.materials.AbstractMultilayerMaterial,
+    ):
+        """
+        Interpolating the stack over the angle of incidence reproduces solving
+        it for every ray, and does so better the more nodes it is given.
+        """
+        angle = na.linspace(0, 20, axis="angle", num=25) * u.deg
+        rays = optika.rays.RayVectorArray(
+            wavelength=_wavelength,
+            direction=na.Cartesian3dVectorArray(np.sin(angle), 0, np.cos(angle)),
+        )
+        normal = na.Cartesian3dVectorArray(0, 0, -1)
+
+        expected = a.efficiency(rays, normal)
+
+        # measured against the size of the response rather than pointwise,
+        # since a multilayer stack can pass through a deep null where the
+        # relative error of any approximation is unbounded but the absolute
+        # error is negligible
+        scale = np.abs(expected).max()
+
+        def error(num: int) -> float:
+            result = dataclasses.replace(a, num_interpolation=num).efficiency(
+                rays=rays,
+                normal=normal,
+            )
+            return np.abs(result - expected).max() / scale
+
+        coarse, fine = error(8), error(64)
+
+        assert coarse < 0.05
+        assert fine <= coarse
+
+    def test_efficiency_interpolated_scalar(
+        self,
+        a: optika.materials.AbstractMultilayerMaterial,
+    ):
+        """With a single angle of incidence there is nothing to interpolate
+        over, so the stack is solved directly."""
+        rays = optika.rays.RayVectorArray(
+            wavelength=200 * u.AA,
+            direction=na.Cartesian3dVectorArray(0, 0, 1),
+        )
+        normal = na.Cartesian3dVectorArray(0, 0, -1)
+
+        result = dataclasses.replace(a, num_interpolation=8).efficiency(
+            rays=rays,
+            normal=normal,
+        )
+
+        assert np.all(result == a.efficiency(rays, normal))
+
     def test_layers(self, a: optika.materials.AbstractMultilayerMaterial):
         result = a.layers
         if not isinstance(result, optika.materials.AbstractLayer):

--- a/optika/materials/_thin_films.py
+++ b/optika/materials/_thin_films.py
@@ -128,6 +128,13 @@ class ThinFilmFilter(
     mesh: meshes.AbstractMesh = dataclasses.MISSING
     """The mesh backing supporting this thin-film filter."""
 
+    num_interpolation: None | int = None
+    """
+    The number of nodes used to interpolate the response of this stack over
+    the angle of incidence, or :obj:`None` to solve it for every ray.
+    See :attr:`~optika.materials.AbstractMultilayerMaterial.num_interpolation`.
+    """
+
     @property
     def shape(self) -> dict[str, int]:
         return na.broadcast_shapes(


### PR DESCRIPTION
Solving the transfer matrices of a multilayer stack costs far more than the raytrace it belongs to. Tracing the ESIS design over nine wavelengths spends 3.25 s of 3.70 s inside `multilayer_efficiency`, and `area_effective` — the one caller that genuinely needs the coatings, since #204 stopped the others from computing them — inherits all of it.

The response is a smooth function of the angle of incidence, and a surface spans very little of that angle. Across the range each ESIS surface actually covers, at 620 Å:

```
 surface |    angle range |       efficiency range |  8-node interp error
       3 |  0.68- 2.63 deg |    0.24912-  0.25002 |  1.07e-05
       5 |  0.00- 5.17 deg |    0.20749-  0.21605 |  2.02e-04
       6 |  5.57- 7.92 deg |    0.13290-  0.13519 |  1.60e-05
```

## What this adds

`num_interpolation` on the multilayer materials. Left at `None`, the default, every ray is solved exactly as before and nothing changes for any existing caller. Set to an integer, the stack is evaluated at that many angles spanning the range the rays cover, and the rest is interpolated: 9 × 32 solves instead of 108,900.

## Benchmark

ESIS single-channel, nine wavelengths, jitter disabled so the error is measurable:

```
                                   |    time | speedup |  max error
     exact, coatings on full field |   2.41s |   1.00x |   0.0000%
     angle interpolation (32) only |   0.81s |   3.01x |   0.0001%
         geometry only (the floor) |   0.38s |   6.47x |        n/a

  linearize:  3.97s -> 2.19s  (1.8x)
```

Per-ray throughput error against the exact solve:

```
   nodes |        max |        rms
       4 |   1.33e-04 |   4.26e-05
       8 |   2.49e-05 |   8.29e-06
      16 |   5.44e-06 |   1.80e-06
      32 |   1.28e-06 |   4.21e-07
      64 |   3.08e-07 |   1.06e-07
```

Clean second-order convergence, and the time is flat from 4 nodes to 64 because the table costs almost nothing next to the rays. There is no reason to be sparing with them.

## Polarization

Deliberately not handled. The two `efficiency` implementations are factored into a shared `_efficiency` which averages the two polarization states *before* interpolating rather than after. Interpolation is linear, so this gives an identical answer for half the work — it is worth 3.01x against 2.64x for the version that interpolated each state separately, at exactly the same accuracy.

The docstring says what to change when polarization does arrive: drop the two `.average` calls and interpolate `.s` and `.p` on their own. The angle of incidence remains the only variable worth tabulating, since what polarization adds is a rotation into the plane of incidence, which varies over the pupil but costs almost nothing next to the stack.

Two things it also records, both measured rather than assumed. A table accurate for the average is not automatically accurate for the two states — `p` runs about 1.5x worse than `s`, though the same order. And a coherent (Jones) treatment needs more than removing the averaging, because `multilayer_efficiency` has already discarded the phase at `reflectivity = np.square(np.abs(r))`; interpolating that would have to be over real and imaginary parts, never magnitude and phase, since phase wraps.

## The sharp edge, stated plainly

Accuracy depends on the angular span measured against the width of the features in the response, not on the node count alone. Pushing the same 8-node table wider on the ESIS grating:

```
   0-20 deg, 8 nodes: s 1.87e-03  p 2.16e-03  avg 1.99e-03
   0-45 deg, 8 nodes: s 1.53e-01  p 1.85e-02  avg 7.35e-02
```

15% at 45°. This is why the default is `None` and the docstring says to check a new system against it before trusting it.

My first version of the test asserted pointwise relative error and the `MultilayerMirror` cases failed at 4.2 and 23.1. That was the metric's fault, not the method's: those stacks have a Bragg null where reflectivity runs from 1.33e-06 to 9.12e-02 over 0–20°, and relative error near a zero is unbounded while the absolute error stays negligible. The test now normalizes by the peak response, which is what matters radiometrically.

## Tests

`test_efficiency_interpolated` runs for every concrete multilayer material and asserts the peak-normalized error is under 5% at 8 nodes and does not get worse at 64. `test_efficiency_interpolated_scalar` covers the path where there is no angle axis to interpolate over and the stack is solved directly.

Full suite: 17758 passed, 304 skipped, 17 xfailed. The changed modules are at 100% line coverage.

## What this rules out

I had proposed a cheaper alternative first: evaluate the coatings on a coarse field grid while keeping geometry on the full one, since throughput varies only 0.1–0.24% across the field. Measured head to head, it loses on both axes, and the two do not compose:

```
     coarse-field split (5x5) only |   1.22s |   2.00x |   0.1148%
     angle interpolation (32) only |   0.81s |   3.01x |   0.0001%
                              both |   0.94s |   2.61x |   0.1147%
```

Stacking them is worse than interpolation alone, because the split works by adding a second raytrace pass for the coatings, and that pass only pays for itself while coatings are expensive. It should be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
