### PR TITLE
Solve for the stops once when linearizing, not three times

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -636,11 +636,16 @@ class AbstractSequentialSystem(
     def _calc_rayfunction_stops(
         self,
         wavelength_input: na.ScalarLike,
-        axis_pupil_stop: str,
-        axis_field_stop: str,
-        samples_pupil_stop: int = 101,
-        samples_field_stop: int = 101,
+        axis_pupil_stop: None | str = None,
+        axis_field_stop: None | str = None,
+        samples_pupil_stop: int = 21,
+        samples_field_stop: int = 21,
     ) -> optika.rays.RayFunctionArray:
+        if axis_pupil_stop is None:
+            axis_pupil_stop = self._axis_pupil_stop
+        if axis_field_stop is None:
+            axis_field_stop = self._axis_field_stop
+
         surfaces = self.surfaces_all
 
         index_pupil_stop = self.index_pupil_stop
@@ -699,13 +704,7 @@ class AbstractSequentialSystem(
         which is designed to exactly strike the borders of both the field
         stop and the pupil stop.
         """
-        return self._calc_rayfunction_stops(
-            wavelength_input=self.grid_input.wavelength,
-            axis_pupil_stop=self._axis_pupil_stop,
-            axis_field_stop=self._axis_field_stop,
-            samples_pupil_stop=21,
-            samples_field_stop=21,
-        )
+        return self._calc_rayfunction_stops(self.grid_input.wavelength)
 
     @property
     def _axis_stops(self) -> tuple[str, str]:
@@ -796,32 +795,6 @@ class AbstractSequentialSystem(
             y=na.linspace(-1, 1, axis="_pupil_y", num=11),
         )
 
-    def _calc_rayfunction_stops_denormalize(
-        self,
-        wavelength: na.ScalarLike,
-    ) -> optika.rays.RayFunctionArray:
-        """
-        Solve for the stops on the sampling that :meth:`_denormalize_grid`
-        uses, which is the expensive half of denormalizing a grid.
-
-        Separated so that a caller denormalizing several grids on the same
-        wavelengths can solve once and pass the result to
-        :meth:`_denormalize_grid_from_rays`, instead of repeating a solve
-        which depends on nothing else.
-
-        Parameters
-        ----------
-        wavelength
-            The wavelengths to solve at.
-        """
-        return self._calc_rayfunction_stops(
-            wavelength_input=wavelength,
-            axis_pupil_stop=self._axis_pupil_stop,
-            axis_field_stop=self._axis_field_stop,
-            samples_pupil_stop=21,
-            samples_field_stop=21,
-        )
-
     def _denormalize_grid(
         self,
         grid: optika.vectors.ObjectVectorArray,
@@ -834,7 +807,7 @@ class AbstractSequentialSystem(
 
         return self._denormalize_grid_from_rays(
             grid=grid,
-            rayfunction_stops=self._calc_rayfunction_stops_denormalize(grid.wavelength),
+            rayfunction_stops=self._calc_rayfunction_stops(grid.wavelength),
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
         )
@@ -855,8 +828,8 @@ class AbstractSequentialSystem(
         grid
             The grid to denormalize.
         rayfunction_stops
-            The result of :meth:`_calc_rayfunction_stops_denormalize` on the
-            wavelengths of `grid`.
+            The result of :meth:`_calc_rayfunction_stops` on the wavelengths
+            of `grid`.
         normalized_field
             A boolean flag indicating whether the field of `grid` is given in
             normalized or physical units.
@@ -1744,7 +1717,7 @@ class AbstractSequentialSystem(
         # expensive part of that is solving for the stops, which depends on
         # nothing but the wavelengths.  Solve once here and hand each of them
         # a grid which is already physical.
-        stops = self._calc_rayfunction_stops_denormalize(wavelength)
+        stops = self._calc_rayfunction_stops(wavelength)
 
         def denormalize(
             pupil: na.AbstractCartesian2dVectorArray,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -781,6 +781,47 @@ class AbstractSequentialSystem(
         """
         return self.pupil_boundary.max(self._axis_stops)
 
+    @property
+    def _pupil_vertices_default(self) -> na.Cartesian2dVectorArray:
+        """
+        The pupil grid :meth:`area_effective` uses when given none.
+
+        Its components are cell *vertices*, since the effective area weights
+        each ray by the area of its pupil cell, whereas
+        :attr:`grid_input` holds the points that rays are traced at.  That is
+        why the two cannot share a default.
+        """
+        return na.Cartesian2dVectorArray(
+            x=na.linspace(-1, 1, axis="_pupil_x", num=11),
+            y=na.linspace(-1, 1, axis="_pupil_y", num=11),
+        )
+
+    def _calc_rayfunction_stops_denormalize(
+        self,
+        wavelength: na.ScalarLike,
+    ) -> optika.rays.RayFunctionArray:
+        """
+        Solve for the stops on the sampling that :meth:`_denormalize_grid`
+        uses, which is the expensive half of denormalizing a grid.
+
+        Separated so that a caller denormalizing several grids on the same
+        wavelengths can solve once and pass the result to
+        :meth:`_denormalize_grid_from_rays`, instead of repeating a solve
+        which depends on nothing else.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelengths to solve at.
+        """
+        return self._calc_rayfunction_stops(
+            wavelength_input=wavelength,
+            axis_pupil_stop=self._axis_pupil_stop,
+            axis_field_stop=self._axis_field_stop,
+            samples_pupil_stop=21,
+            samples_field_stop=21,
+        )
+
     def _denormalize_grid(
         self,
         grid: optika.vectors.ObjectVectorArray,
@@ -791,16 +832,40 @@ class AbstractSequentialSystem(
         if (not normalized_field) and (not normalized_pupil):
             return grid
 
+        return self._denormalize_grid_from_rays(
+            grid=grid,
+            rayfunction_stops=self._calc_rayfunction_stops_denormalize(grid.wavelength),
+            normalized_field=normalized_field,
+            normalized_pupil=normalized_pupil,
+        )
+
+    def _denormalize_grid_from_rays(
+        self,
+        grid: optika.vectors.ObjectVectorArray,
+        rayfunction_stops: optika.rays.RayFunctionArray,
+        normalized_field: bool = True,
+        normalized_pupil: bool = True,
+    ) -> optika.vectors.ObjectVectorArray:
+        """
+        Map a normalized grid onto the field and pupil that the given stop
+        rayfunction describes.
+
+        Parameters
+        ----------
+        grid
+            The grid to denormalize.
+        rayfunction_stops
+            The result of :meth:`_calc_rayfunction_stops_denormalize` on the
+            wavelengths of `grid`.
+        normalized_field
+            A boolean flag indicating whether the field of `grid` is given in
+            normalized or physical units.
+        normalized_pupil
+            A boolean flag indicating whether the pupil of `grid` is given in
+            normalized or physical units.
+        """
         axis_field = self._axis_field_stop
         axis_pupil = self._axis_pupil_stop
-
-        rayfunction_stops = self._calc_rayfunction_stops(
-            wavelength_input=grid.wavelength,
-            axis_pupil_stop=axis_pupil,
-            axis_field_stop=axis_field,
-            samples_pupil_stop=21,
-            samples_field_stop=21,
-        )
 
         result = grid.copy_shallow()
 
@@ -1526,10 +1591,7 @@ class AbstractSequentialSystem(
         if field is None:
             field = self.grid_input.field
         if pupil is None:
-            pupil = na.Cartesian2dVectorArray(
-                x=na.linspace(-1, 1, axis="_pupil_x", num=11),
-                y=na.linspace(-1, 1, axis="_pupil_y", num=11),
-            )
+            pupil = self._pupil_vertices_default
 
         grid = optika.vectors.ObjectVectorArray(
             wavelength=wavelength,
@@ -1665,16 +1727,47 @@ class AbstractSequentialSystem(
         # `area_effective` interprets `pupil` as cell vertices (it needs them to
         # compute the pupil cell areas), while `distortion` and `vignetting`
         # trace at sample points, so give them the cell centers of the vertices.
+        # With no pupil given the two fall back to different grids, since
+        # `grid_input.pupil` holds points and cannot serve as vertices.
         if pupil is not None:
             pupil_centers = pupil.cell_centers(axis=tuple(na.shape(pupil)))
         else:
-            pupil_centers = None
+            pupil = self._pupil_vertices_default
+            pupil_centers = self.grid_input.pupil
+
+        if wavelength is None:
+            wavelength = self.grid_input.wavelength
+        if field is None:
+            field = self.grid_input.field
+
+        # Each of the three fits below denormalizes its own grid, and the
+        # expensive part of that is solving for the stops, which depends on
+        # nothing but the wavelengths.  Solve once here and hand each of them
+        # a grid which is already physical.
+        stops = self._calc_rayfunction_stops_denormalize(wavelength)
+
+        def denormalize(
+            pupil: na.AbstractCartesian2dVectorArray,
+        ) -> optika.vectors.ObjectVectorArray:
+            return self._denormalize_grid_from_rays(
+                grid=optika.vectors.ObjectVectorArray(
+                    wavelength=wavelength,
+                    field=field,
+                    pupil=pupil,
+                ),
+                rayfunction_stops=stops,
+                normalized_field=normalized_field,
+                normalized_pupil=normalized_pupil,
+            )
+
+        grid_area = denormalize(pupil)
+        grid_fit = denormalize(pupil_centers)
 
         kwargs = dict(
             wavelength=wavelength,
-            field=field,
-            normalized_field=normalized_field,
-            normalized_pupil=normalized_pupil,
+            field=grid_area.field,
+            normalized_field=False,
+            normalized_pupil=False,
         )
         # the cosine of the refracted angle at which light strikes the sensor,
         # computed the same way as
@@ -1693,11 +1786,11 @@ class AbstractSequentialSystem(
         )
 
         return LinearSystem(
-            area_effective=self.area_effective(pupil=pupil, **kwargs),
-            distortion=self.distortion(pupil=pupil_centers, degree=degree, **kwargs),
+            area_effective=self.area_effective(pupil=grid_area.pupil, **kwargs),
+            distortion=self.distortion(pupil=grid_fit.pupil, degree=degree, **kwargs),
             sensor=self.sensor,
             direction=direction,
-            vignetting=self.vignetting(pupil=pupil_centers, degree=degree, **kwargs),
+            vignetting=self.vignetting(pupil=grid_fit.pupil, degree=degree, **kwargs),
         )
 
     def _rayfunction_and_axes(


### PR DESCRIPTION
`_denormalize_grid` does two unrelated things: it solves for where the stops put the field and pupil, and it applies an affine map. The solve costs 0.13 s and depends on nothing but the wavelengths. The map is free.

`linearize` denormalizes three grids on the same wavelengths, one per fit, so it solved three times for the same answer, plus a fourth for `rayfunction_default`:

```
a cold linearize(wavelength=<9 points>):
   solve 1: wavelength {}                  0.19 s
   solve 2: wavelength {'wavelength': 9}   0.13 s
   solve 3: wavelength {'wavelength': 9}   0.13 s
   solve 4: wavelength {'wavelength': 9}   0.13 s
   4 solves, 0.59 s of 3.98 s (15%)
```

There is a cache for this, `rayfunction_stops`, and it works. But it is keyed on `grid_input.wavelength`, so the moment a caller supplies its own wavelengths it never hits. Nor was the cost amortised across calls: a second `linearize` on the same wavelengths ran all four again.

## What this does

Splits the two halves apart so a caller with several grids can solve once:

| | |
|---|---|
| `_calc_rayfunction_stops_denormalize` | the solve |
| `_denormalize_grid_from_rays` | the affine map |
| `_denormalize_grid` | both, exactly as before |

`linearize` then solves once, denormalizes both of its grids, and passes each fit a grid that is already physical, so their own `_denormalize_grid` hits its early return and never solves.

```
   2 solves, 0.29 s of 3.59 s (8%)
```

The remaining one is `rayfunction_default`'s, which is on the default grid rather than the one being linearized. That is a separate question about where `direction` should come from.

## Nothing changes

Every deterministic product of `linearize`, compared against `main` in a worktree on `esis.flights.f1.optics.design_single()` over nine wavelengths. All 37 arrays equal bit for bit:

```
distortion      20 arrays   IDENTICAL
vignetting      10 arrays   IDENTICAL
direction        1 arrays   IDENTICAL
scene            3 arrays   IDENTICAL     # what the distortion is fit to
sensor           2 arrays   IDENTICAL
illumination     1 arrays   IDENTICAL     # what the vignetting is fit to
```

This is exact rather than approximate because the two stop solves it replaces were already producing identical results, which I verified directly, and because `linearize` keeps the existing order of operations. In particular it still takes pupil cell centers from the *normalized* vertices, before denormalizing, as it does today. Denormalizing first would be equivalent in exact arithmetic, since an affine map commutes with an average, but differs by an ulp in floating point:

```
  pupil.x: bit-identical False   max|d| 1.421e-14  rel 1.749e-16   (ulp ~ 1.4e-14)
```

Not worth giving up a provable claim for.

## One wrinkle

The fits can no longer be handed a grid of `None`, so `linearize` resolves the defaults itself. The pupil grid `area_effective` invents when given none moves out of the method body into `_pupil_vertices_default`, so both can reach it.

The two fits keep falling back to `grid_input.pupil` exactly as before. Those two defaults differ because `area_effective` needs cell **vertices**, to weight each ray by the area of its pupil cell, while the fits need sample **points**. Reconciling them is #187's job, and doing it here would silently change results in a PR that is otherwise provably inert.

*(Edited: this paragraph previously claimed #187 would also fix a knife-edge sampling error making `vignetting`'s illumination 15% low. That was wrong — I measured a grid the code does not use. `grid_input` is built with `centers=True`, so its samples are already interior, and the real effect is rms 1.9% on the normalized illumination. Retracted in detail at https://github.com/sun-data/optika/pull/208#issuecomment-5448145223.)*

## Tests

Full suite: 17774 passed, 304 skipped, 17 xfailed. `_sequential.py` at 100% line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

