### PR TITLE
Trace once for the distortion, vignetting, and sensor angle

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1364,38 +1364,12 @@ class AbstractSequentialSystem(
             efficiency=False,
         )
 
-        if not axis_wavelength:
-            raise ValueError(
-                "fitting a distortion model requires the wavelength grid "
-                "to vary along its own logical axis."
-            )
-        (axis_wavelength,) = axis_wavelength
-
-        coordinates_scene = na.SpectralPositionalVectorArray(
-            wavelength=rays.inputs.wavelength,
-            position=rays.inputs.field,
-        )
-
-        unvignetted = rays.outputs.unvignetted
-        where = unvignetted.any(axis_pupil)
-
-        # average only the unvignetted rays, falling back to all of the rays
-        # for field points excluded from the fit so that the mean is never
-        # empty. The sensor-plane positions are expressed in pixel coordinates,
-        # so the fitted distortion maps the scene onto the pixel grid.
-        coordinates_sensor = np.mean(
-            self.sensor.pixels(rays.outputs.position.xy),
-            axis=axis_pupil,
-            where=unvignetted | ~where,
-        )
-
-        return optika.distortion.PolynomialDistortionModel(
-            coordinates_scene=coordinates_scene,
-            coordinates_sensor=coordinates_sensor,
+        return self._fit_distortion(
+            rays=rays,
             axis_wavelength=axis_wavelength,
             axis_field=axis_field,
+            axis_pupil=axis_pupil,
             degree=degree,
-            where=where,
         )
 
     def vignetting(
@@ -1454,6 +1428,102 @@ class AbstractSequentialSystem(
             efficiency=False,
         )
 
+        return self._fit_vignetting(
+            rays=rays,
+            axis_wavelength=axis_wavelength,
+            axis_field=axis_field,
+            axis_pupil=axis_pupil,
+            degree=degree,
+        )
+
+    def _fit_distortion(
+        self,
+        rays: optika.rays.RayFunctionArray,
+        axis_wavelength: tuple[str, ...],
+        axis_field: tuple[str, str],
+        axis_pupil: tuple[str, str],
+        degree: int,
+    ) -> optika.distortion.PolynomialDistortionModel:
+        """
+        Fit a polynomial distortion model to rays which have already been traced.
+
+        Separated from :meth:`distortion` so that a caller needing both models,
+        such as :meth:`linearize`, can trace once and fit twice.
+
+        Parameters
+        ----------
+        rays
+            The traced rays, from :meth:`_rayfunction_and_axes`.
+        axis_wavelength
+            The normalized wavelength axis of `rays`.
+        axis_field
+            The normalized field axes of `rays`.
+        axis_pupil
+            The normalized pupil axes of `rays`.
+        degree
+            The degree of the polynomial model.
+        """
+        if not axis_wavelength:
+            raise ValueError(
+                "fitting a distortion model requires the wavelength grid "
+                "to vary along its own logical axis."
+            )
+        (axis_wavelength,) = axis_wavelength
+
+        coordinates_scene = na.SpectralPositionalVectorArray(
+            wavelength=rays.inputs.wavelength,
+            position=rays.inputs.field,
+        )
+
+        unvignetted = rays.outputs.unvignetted
+        where = unvignetted.any(axis_pupil)
+
+        # average only the unvignetted rays, falling back to all of the rays
+        # for field points excluded from the fit so that the mean is never
+        # empty. The sensor-plane positions are expressed in pixel coordinates,
+        # so the fitted distortion maps the scene onto the pixel grid.
+        coordinates_sensor = np.mean(
+            self.sensor.pixels(rays.outputs.position.xy),
+            axis=axis_pupil,
+            where=unvignetted | ~where,
+        )
+
+        return optika.distortion.PolynomialDistortionModel(
+            coordinates_scene=coordinates_scene,
+            coordinates_sensor=coordinates_sensor,
+            axis_wavelength=axis_wavelength,
+            axis_field=axis_field,
+            degree=degree,
+            where=where,
+        )
+
+    def _fit_vignetting(
+        self,
+        rays: optika.rays.RayFunctionArray,
+        axis_wavelength: tuple[str, ...],
+        axis_field: tuple[str, str],
+        axis_pupil: tuple[str, str],
+        degree: int,
+    ) -> optika.radiometry.PolynomialVignettingModel:
+        """
+        Fit a polynomial vignetting model to rays which have already been traced.
+
+        Separated from :meth:`vignetting` so that a caller needing both models,
+        such as :meth:`linearize`, can trace once and fit twice.
+
+        Parameters
+        ----------
+        rays
+            The traced rays, from :meth:`_rayfunction_and_axes`.
+        axis_wavelength
+            The normalized wavelength axis of `rays`.
+        axis_field
+            The normalized field axes of `rays`.
+        axis_pupil
+            The normalized pupil axes of `rays`.
+        degree
+            The degree of the polynomial model.
+        """
         if not axis_wavelength:
             raise ValueError(
                 "fitting a vignetting model requires the wavelength grid "
@@ -1742,28 +1812,55 @@ class AbstractSequentialSystem(
             normalized_field=False,
             normalized_pupil=False,
         )
+        # the distortion and vignetting fits read the same rays, and so does
+        # `direction`, so trace them once.  None of the three reads the
+        # intensity: `direction` is built from the geometry and from the index
+        # of refraction, which is computed either way.
+        rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
+            pupil=grid_fit.pupil,
+            efficiency=False,
+            **kwargs,
+        )
+
         # the cosine of the refracted angle at which light strikes the sensor,
         # computed the same way as
-        # :meth:`~optika.sensors.AbstractImagingSensor.collect` and averaged
-        # over the grid.
-        rays = self.rayfunction_default.outputs
+        # :meth:`~optika.sensors.AbstractImagingSensor.collect`.
+        outputs = rays.outputs
         direction = self.sensor.material.direction_refracted(
-            wavelength=rays.wavelength,
-            direction=rays.direction,
-            n=rays.n,
-            normal=self.sensor.sag.normal(rays.position),
+            wavelength=outputs.wavelength,
+            direction=outputs.direction,
+            n=outputs.n,
+            normal=self.sensor.sag.normal(outputs.position),
         )
-        axis_grid = self.axis_wavelength_ + self.axis_field_ + self.axis_pupil_
+
+        # averaged over the whole grid, wavelength included.  It has to end up
+        # a scalar: `AbstractImagingSensor.expose` indexes `direction` by the
+        # cell centers of the *scene's* wavelength grid, which has nothing to
+        # do with the grid being linearized, so an array would either fail to
+        # broadcast or pair up wavelengths which are not the same.
+        axis_grid = axis_wavelength + axis_field + axis_pupil
         direction = direction.mean(
             axis=tuple(ax for ax in axis_grid if ax in na.shape(direction)),
         )
 
         return LinearSystem(
             area_effective=self.area_effective(pupil=grid_area.pupil, **kwargs),
-            distortion=self.distortion(pupil=grid_fit.pupil, degree=degree, **kwargs),
+            distortion=self._fit_distortion(
+                rays=rays,
+                axis_wavelength=axis_wavelength,
+                axis_field=axis_field,
+                axis_pupil=axis_pupil,
+                degree=degree,
+            ),
             sensor=self.sensor,
             direction=direction,
-            vignetting=self.vignetting(pupil=grid_fit.pupil, degree=degree, **kwargs),
+            vignetting=self._fit_vignetting(
+                rays=rays,
+                axis_wavelength=axis_wavelength,
+                axis_field=axis_field,
+                axis_pupil=axis_pupil,
+                degree=degree,
+            ),
         )
 
     def _rayfunction_and_axes(

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -492,6 +492,12 @@ class AbstractTestAbstractSequentialSystem(
         assert result.sensor is a.sensor
         assert result.field_stop is None
 
+        # `direction` has to be a scalar.  `expose` indexes it by the cell
+        # centers of the *scene's* wavelength grid, which is unrelated to the
+        # grid linearized here, so an array would either fail to broadcast or
+        # silently pair up wavelengths which are not the same.
+        assert na.shape(result.direction) == {}
+
     def test_spot_diagram(self, a: optika.systems.AbstractSequentialSystem):
         fig, axs = a.spot_diagram()
         assert isinstance(fig, plt.Figure)


### PR DESCRIPTION
**Depends on #211 and must merge after it.** Opened against that branch so the diff shows only this change; retargeted to `main` immediately, so deleting #211's branch on merge cannot close this PR.

## Why

`linearize` fits the distortion and the vignetting from the same rays, traced with identical arguments, and then traced a third time through `rayfunction_default` for the cosine of the angle at which light strikes the sensor. None of the three reads the intensity.

## What changes

`distortion` and `vignetting` keep their behaviour; their fitting bodies move into `_fit_distortion` and `_fit_vignetting`, so a caller needing both can trace once and fit twice. `direction` comes from those same rays.

```
before: 4 raytraces, 4 stop solves, 3.46 s
after:  2 raytraces, 1 stop solve,  2.64 s

with `num_interpolation` set:      1.66 s -> 1.06 s
```

## What moves, and what does not

```
distortion      20  IDENTICAL
vignetting      10  IDENTICAL
scene            3  IDENTICAL
sensor           2  IDENTICAL
illumination     1  IDENTICAL
direction        1  CHANGED by 2.31%
```

`direction` was evaluated on `grid_input.wavelength` — a single value, 629.77 Å for ESIS — no matter which band was asked for. It is now averaged over the band being linearized. The old value was worse the further the requested band sat from that wavelength:

```
today (on grid_input.wavelength):  0.880400+0.044822j

if computed on the grid actually being linearized:
   580-640 A: differs by  5.36%
   300-350 A: differs by 12.27%
   900-1000 A: differs by 22.73%
```

It feeds `sensor.expose`, which uses it for the path length through the depletion region, so this is a radiometric correction rather than a refactor artifact.

## The trap this had to avoid

The existing averaging line reads:

```python
axis_grid = self.axis_wavelength_ + self.axis_field_ + self.axis_pupil_
direction = direction.mean(axis=tuple(ax for ax in axis_grid if ax in na.shape(direction)))
```

`axis_wavelength_` is derived from `grid_input`, which holds a *scalar* wavelength for ESIS, so it is `()`. That was harmless while `direction` came from `rayfunction_default`, which has no wavelength axis either. Fed the shared trace, the axis survives:

```
shared trace, existing line  shape {'wavelength': 9}      <- the landmine
shared trace, wavelength too shape {}                     0.895272+0.030887j
```

An array `direction` is not merely different, it is broken. `expose` indexes it by the cell centers of the *scene's* wavelength grid, which has nothing to do with the grid being linearized:

```
   scene 10 edges ( 9 centres) -> NO ERROR              <- silently pairs unrelated wavelengths
   scene  5 edges ( 4 centres) -> ValueError: shapes ({'wavelength': 4}, {'wavelength': 9}) are not compatible
   scene 20 edges (19 centres) -> ValueError: shapes ({'wavelength': 19}, {'wavelength': 9}) are not compatible
```

So the average now names the wavelength axis explicitly, and `test_linearize` asserts `direction` is a scalar.

Worth knowing while reviewing: `_linear_test`'s sensor is an ideal material that ignores `direction` entirely (9000 photons in, 9000 electrons out, and the mismatched-shape case does not even raise), so none of `LinearSystem`'s own tests exercise it.

## Tests

Full suite: 17768 passed, 304 skipped, 17 xfailed. `_sequential.py` at 100% line coverage. Six `ndfilters` tests fail with a numba `ReferenceError: underlying object has vanished`, identically on `main` — a pre-existing local flake, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
