### PR TITLE
Let a depletion model not be shaped by the measurement it was fitted to

### DIFF
--- a/optika/sensors/materials/depletion/_depletion.py
+++ b/optika/sensors/materials/depletion/_depletion.py
@@ -146,9 +146,12 @@ class JanesickDepletionModel(
 
     @property
     def shape(self) -> dict[str, int]:
+        # `mcc_measured` is left out: the measurement this model was fitted
+        # against is sampled along an axis of its own, which says nothing
+        # about the shape of the model and need not agree with the axes of
+        # any other measurement alongside it.
         return na.broadcast_shapes(
             na.shape(self.thickness),
             na.shape(self.thickness_substrate),
             na.shape(self.width_pixel),
-            na.shape(self.mcc_measured),
         )

--- a/optika/sensors/materials/depletion/_depletion_test.py
+++ b/optika/sensors/materials/depletion/_depletion_test.py
@@ -74,3 +74,16 @@ class TestJanesickDepletionModel(
         assert isinstance(result, na.AbstractFunctionArray)
         assert np.all(result.inputs > 0 * u.AA)
         assert np.all(result.outputs > 0)
+
+    def test_shape_excludes_mcc_measured(
+        self,
+        a: optika.sensors.materials.depletion.JanesickDepletionModel,
+    ):
+        """
+        The measurement this model was fitted against does not shape it.
+
+        It is sampled along an axis of its own, which need not agree with the
+        axes of any other measurement carried alongside it, and which says
+        nothing about the shape of the model.
+        """
+        assert set(na.shape(a.mcc_measured)).isdisjoint(a.shape)


### PR DESCRIPTION
`JanesickDepletionModel.shape` counted the measured mean charge capture among
the things which shape the model:

```python
return na.broadcast_shapes(
    na.shape(self.thickness),
    na.shape(self.thickness_substrate),
    na.shape(self.width_pixel),
    na.shape(self.mcc_measured),      # <-
)
```

It is not one of them. The measurement is sampled along an axis of its own, kept
so residuals can be computed against the fit, and its axis has nothing to say
about the shape of the model.

Because it was counted, a sensor material holding this model alongside a measured
quantum efficiency could not be asked for its shape at all:

```
ValueError: shapes ({}, ..., {'wavelength': 4}, {'wavelength': 84}) are not compatible
```

Four samples of charge capture against eighty-four of quantum efficiency, sharing
the name of their axis and disagreeing on its length. That is every ESIS as-built
model, which could not be traced as a result.

The sensor material above this one already declares itself unshaped by its own
measurement (`AbstractBackilluminatedCCDMaterial.shape` returns `dict()`). This
says the same of the model below.

## Testing

One test: that the axes of `mcc_measured` are disjoint from the model's shape.
22 tests pass in `optika/sensors/materials/depletion`, 271 across `optika/sensors`.

## Note

Fully effective only with sun-data/named-arrays#226, which makes `na.shape`
honour declarations like this one; without it `optika.shape` honours them and
`na.shape` does not.
