### PR TITLE
Cover interpolating a coating for rays which carry an uncertainty

### DIFF
--- a/optika/materials/_tests/test_multilayers.py
+++ b/optika/materials/_tests/test_multilayers.py
@@ -330,6 +330,34 @@ class AbstractTestAbstractMultilayerMaterial(
         assert coarse < 0.05
         assert fine <= coarse
 
+    def test_efficiency_interpolated_uncertain(
+        self,
+        a: optika.materials.AbstractMultilayerMaterial,
+    ):
+        """
+        The interpolation works on rays whose direction carries an uncertainty
+        distribution, which is how a system built with `num_distribution` set
+        traces them.
+        """
+        angle = na.NormalUncertainScalarArray(
+            na.linspace(0, 20, axis="angle", num=25) * u.deg,
+            width=0.5 * u.deg,
+            num_distribution=3,
+        )
+        rays = optika.rays.RayVectorArray(
+            wavelength=_wavelength,
+            direction=na.Cartesian3dVectorArray(np.sin(angle), 0, np.cos(angle)),
+        )
+        normal = na.Cartesian3dVectorArray(0, 0, -1)
+
+        expected = a.efficiency(rays, normal)
+        result = dataclasses.replace(a, num_interpolation=64).efficiency(
+            rays=rays,
+            normal=normal,
+        )
+
+        assert np.abs(result - expected).max() < 0.05 * np.abs(expected).max()
+
     def test_efficiency_interpolated_scalar(
         self,
         a: optika.materials.AbstractMultilayerMaterial,


### PR DESCRIPTION
`num_interpolation` (#210) shipped with nothing in the suite enabling it. The default is `None`, which takes the exact path, so the feature was untested in *every* configuration. Enabling it in esis broke immediately, on a system built with `num_distribution`:

```
ValueError: if `axis` is `None`, `xp` must have only one axis
```

This adds the test that would have caught it: rays whose angle of incidence carries a distribution, for every concrete multilayer material.

## The bug was not in this package

`named_arrays.interp` accepted the axis to interpolate along and passed it to neither of the two interpolations it performs for an uncertain array, so the table was taken to have exactly one axis and anything else raised — whatever the caller asked for. Only when `xp` was uncertain; an uncertain `fp` alone works, because the axis is then settled by an `xp` which still has one, which is why it went unnoticed.

Fixed upstream by sun-data/named-arrays#227, released in named-arrays v2.8.0. optika pins `named-arrays~=2.7`, which admits 2.8, so no change to the requirement is needed.

## Why no workaround here

An earlier version of this PR collapsed the interpolation nodes over the distribution, which sidesteps the bug. Dropped, because:

- The upstream fix lands inside the existing pin, so a workaround buys nothing.
- Per-realization nodes are marginally *more* accurate, since each realization's table then spans exactly its own angle range.
- The cost of not collapsing is small: at `num_distribution=11` the table goes from 288 points to 3,168, against the 108,900 rays it replaces — 3% of the work being saved.

It constrained the design for a saving that does not matter, to route around a bug fixed properly elsewhere.

## Verification

Fails on five of the parametrized materials against named-arrays 2.7.0. Passes on 2.8.0.

Full suite on 2.8.0: 17781 passed, 304 skipped, 17 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
