### PR TITLE
Publish through Trusted Publishing, and require named-arrays 2.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI and TestPyPI
+name: Publish to PyPI
 
 on:
   release:
@@ -6,13 +6,15 @@ on:
 
 jobs:
   publish:
-    name: Build and publish to PyPI and TestPyPI
+    name: Build and publish to PyPI
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
       - name: Install pypa/build
         run: >-
           python -m
@@ -28,5 +30,3 @@ jobs:
           --outdir dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy!=6.1.5",
-    "named-arrays~=2.7",
+    "named-arrays~=2.8",
     "pymupdf",
     "joblib",
     "ezdxf",


### PR DESCRIPTION
Release preparation, two changes.

### Trusted Publishing

Uploads are signed against the workflow's own OIDC identity rather than a long-lived API token held as a repository secret. `colorsynth`, `msfc-ccd`, `ndfilters`, and `named-arrays` already publish this way; `regridding` is the last one after this. The publisher is already registered on PyPI.

The file is now the same as `colorsynth`'s: `permissions: id-token: write` on the job, no `with: password:`, `checkout@v4` + `setup-python@v5` unpinned.

It **drops the TestPyPI upload**, as those repos did. It ran *before* the real upload, so it was a second place a release could die on the way to PyPI — a version already on TestPyPI fails the step and skips PyPI entirely.

Releases from here on carry PEP 740 provenance, checkable at `https://pypi.org/integrity/optika/<version>/<filename>/provenance`. `pypa/gh-action-pypi-publish` defaults `attestations` to true but silently ignores it while a password is set.

### `named-arrays~=2.8`

Around thirty classes here declare a `shape` of their own, saying which of the arrays they hold describe their extent and which are calibration data sampled along an axis of its own. Until named-arrays 2.8 (sun-data/named-arrays#226) those declarations only took effect through `optika.shape` — `na.shape` walked the fields and broadcast them together regardless, so which answer you got depended on which function you called.

`AbstractBackilluminatedCCDMaterial.shape` returning `dict()` and `AbstractMultilayerMirror.shape` dropping the wavelength axis of its measured reflectivity were both inert through `na.shape`. A material carrying a measured quantum efficiency at 84 wavelengths and a measured charge capture at 4 is *unshapeable* under the walk, which is what this pin is really about — #213 is only half the fix without it.

Nothing in CI exercises `publish.yml`; it only triggers on `release: published`, so the next release is its first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYjDL98znSud1yFh9chnkP
