### PR TITLE
Name the stop axes in public

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -642,9 +642,9 @@ class AbstractSequentialSystem(
         samples_field_stop: int = 21,
     ) -> optika.rays.RayFunctionArray:
         if axis_pupil_stop is None:
-            axis_pupil_stop = self._axis_pupil_stop
+            axis_pupil_stop = self.axis_pupil_stop
         if axis_field_stop is None:
-            axis_field_stop = self._axis_field_stop
+            axis_field_stop = self.axis_field_stop
 
         surfaces = self.surfaces_all
 
@@ -694,8 +694,22 @@ class AbstractSequentialSystem(
 
         return result
 
-    _axis_pupil_stop: ClassVar[str] = "_stop_pupil"
-    _axis_field_stop: ClassVar[str] = "_stop_field"
+    axis_pupil_stop: ClassVar[str] = "_stop_pupil"
+    """
+    The axis along the edge of the pupil stop.
+
+    This system names the axis rather than taking a name for it, since it is
+    swept internally and not by the caller. The leading underscore marks it as
+    such, and keeps it from colliding with an axis somebody else named.
+    """
+
+    axis_field_stop: ClassVar[str] = "_stop_field"
+    """
+    The axis along the edge of the field stop.
+
+    Named by this system, in the same way and for the same reason as
+    :attr:`axis_pupil_stop`.
+    """
 
     @functools.cached_property
     def rayfunction_stops(self) -> optika.rays.RayFunctionArray:
@@ -707,9 +721,15 @@ class AbstractSequentialSystem(
         return self._calc_rayfunction_stops(self.grid_input.wavelength)
 
     @property
-    def _axis_stops(self) -> tuple[str, str]:
-        """The logical axes along the edges of the two stop surfaces."""
-        return (self._axis_field_stop, self._axis_pupil_stop)
+    def axis_stops(self) -> tuple[str, str]:
+        """
+        The axes along the edges of the two stop surfaces.
+
+        These are the axes of :attr:`field_boundary` and
+        :attr:`pupil_boundary`, and so the ones to reduce over to turn either
+        outline into a measurement of the system.
+        """
+        return (self.axis_field_stop, self.axis_pupil_stop)
 
     @property
     def field_boundary(self) -> na.AbstractCartesian2dVectorArray:
@@ -755,14 +775,14 @@ class AbstractSequentialSystem(
         """
         The lower left corner of this optical system's field of view.
         """
-        return self.field_boundary.min(self._axis_stops)
+        return self.field_boundary.min(self.axis_stops)
 
     @property
     def field_max(self) -> na.AbstractCartesian2dVectorArray:
         """
         The upper right corner of this optical system's field of view.
         """
-        return self.field_boundary.max(self._axis_stops)
+        return self.field_boundary.max(self.axis_stops)
 
     @property
     def pupil_min(self) -> na.AbstractCartesian2dVectorArray:
@@ -770,7 +790,7 @@ class AbstractSequentialSystem(
         The lower left corner of this optical system's entrance pupil in
         physical units.
         """
-        return self.pupil_boundary.min(self._axis_stops)
+        return self.pupil_boundary.min(self.axis_stops)
 
     @property
     def pupil_max(self):
@@ -778,7 +798,7 @@ class AbstractSequentialSystem(
         The upper right corner of this optical system's entrance pupil in
         physical units.
         """
-        return self.pupil_boundary.max(self._axis_stops)
+        return self.pupil_boundary.max(self.axis_stops)
 
     @property
     def _pupil_vertices_default(self) -> na.Cartesian2dVectorArray:
@@ -837,8 +857,8 @@ class AbstractSequentialSystem(
             A boolean flag indicating whether the pupil of `grid` is given in
             normalized or physical units.
         """
-        axis_field = self._axis_field_stop
-        axis_pupil = self._axis_pupil_stop
+        axis_field = self.axis_field_stop
+        axis_pupil = self.axis_pupil_stop
 
         result = grid.copy_shallow()
 

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -113,12 +113,20 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result.outputs, optika.rays.RayVectorArray)
         assert result.ndim >= 2
 
+    def test_axis_stops(self, a: optika.systems.AbstractSequentialSystem):
+        result = a.axis_stops
+        assert result == (a.axis_field_stop, a.axis_pupil_stop)
+
+        # the axes a caller has to name to reduce either outline
+        assert set(result).issubset(na.shape(a.field_boundary))
+        assert set(result).issubset(na.shape(a.pupil_boundary))
+
     def test_field_boundary(self, a: optika.systems.AbstractSequentialSystem):
         result = a.field_boundary
         assert isinstance(result, na.AbstractCartesian2dVectorArray)
 
         # the outline of the field, along the edge of each stop
-        assert set(a._axis_stops).issubset(na.shape(result))
+        assert set(a.axis_stops).issubset(na.shape(result))
 
         if a.object_is_at_infinity:
             assert na.unit(result).is_equivalent(u.deg)
@@ -128,7 +136,7 @@ class AbstractTestAbstractSequentialSystem(
     def test_pupil_boundary(self, a: optika.systems.AbstractSequentialSystem):
         result = a.pupil_boundary
         assert isinstance(result, na.AbstractCartesian2dVectorArray)
-        assert set(a._axis_stops).issubset(na.shape(result))
+        assert set(a.axis_stops).issubset(na.shape(result))
 
         if a.object_is_at_infinity:
             assert na.unit(result).is_equivalent(u.m)
@@ -140,7 +148,7 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(result, na.AbstractCartesian2dVectorArray)
 
         # the corner of the field is a reduction of its outline
-        assert np.all(result == a.field_boundary.min(a._axis_stops))
+        assert np.all(result == a.field_boundary.min(a.axis_stops))
 
         if a.object_is_at_infinity:
             assert na.unit(result).is_equivalent(u.deg)


### PR DESCRIPTION
`field_boundary` ends its docstring by telling the caller what to do next:

> Reduce this outline in whichever way the instrument at hand takes to be its field of view; `field_min` and `field_max` are two such reductions.

And then gave them no supported way to do it. The axis names lived on `_axis_field_stop` and `_axis_pupil_stop`, and the pair on `_axis_stops`, all private. Anyone taking the instruction had to reach past the underscore or recover the axes from the shape of the result.

This came up writing the ESIS instrument paper, which measures a field of view edge to edge rather than corner to corner — exactly the case the docstring describes, and exactly the case `field_min`/`field_max` do not cover. It ended up doing this:

```python
boundary = system.field_boundary
fov = 2 * boundary.length.min(tuple(na.shape(boundary)))
```

reducing over every axis of the result because it could not name the two it meant. That is wrong the moment the system carries an axis of its own — a Monte Carlo population, a wavelength sweep, a channel — and it silently gives a number rather than failing.

## What changes

| was | is |
| --- | --- |
| `_axis_field_stop` | `axis_field_stop` |
| `_axis_pupil_stop` | `axis_pupil_stop` |
| `_axis_stops` | `axis_stops` |

The **values** are unchanged: `"_stop_field"` and `"_stop_pupil"` keep their leading underscore, which marks an axis this system named rather than one the caller did, and keeps it from colliding with an axis somebody else named. Only the attributes holding them become public, and each now carries a docstring saying so.

All uses were inside this package.

## Testing

`test_axis_stops` asserts the pair is `(axis_field_stop, axis_pupil_stop)` and that both are axes of `field_boundary` and of `pupil_boundary` — the contract a caller relies on when reducing either outline. The existing boundary and corner tests already asserted the same subset relation against the private name and now read through the public one.

58 tests pass in `optika/systems/_sequential_test.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYjDL98znSud1yFh9chnkP
