### PR TITLE
Add `Replaceable`, a mixin for copying an object with changes

### DIFF
--- a/optika/_tests/test_mixins.py
+++ b/optika/_tests/test_mixins.py
@@ -44,6 +44,32 @@ class AbstractTestShaped(
             assert isinstance(result[k], int)
 
 
+class AbstractTestReplaceable(
+    abc.ABC,
+):
+    def test_replace(self, a: optika.mixins.Replaceable):
+        # replacing nothing is a copy
+        result = a.replace()
+        assert isinstance(result, type(a))
+        assert result is not a
+
+        fields = dataclasses.fields(a)
+        if not fields:  # pragma: nocover
+            return
+
+        # every field is carried over, and by reference, since the copy is
+        # shallow
+        for f in fields:
+            assert getattr(result, f.name) is getattr(a, f.name)
+
+        # and a field which is named is the one thing which differs
+        name = fields[0].name
+        sentinel = object()
+        result = a.replace(**{name: sentinel})
+        assert getattr(result, name) is sentinel
+        assert getattr(a, name) is not sentinel
+
+
 class AbstractTestPrintable(
     abc.ABC,
 ):

--- a/optika/_tests/test_surfaces.py
+++ b/optika/_tests/test_surfaces.py
@@ -34,6 +34,7 @@ class AbstractTestAbstractSurface(
     test_mixins.AbstractTestDxfWritable,
     test_mixins.AbstractTestPlottable,
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestTransformable,
     test_mixins.AbstractTestShaped,
     test_propagators.AbstractTestAbstractLightPropagator,

--- a/optika/apertures/_apertures.py
+++ b/optika/apertures/_apertures.py
@@ -33,6 +33,7 @@ __all__ = [
 class AbstractAperture(
     optika.mixins.DxfWritable,
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Plottable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,

--- a/optika/apertures/_apertures_test.py
+++ b/optika/apertures/_apertures_test.py
@@ -45,6 +45,7 @@ def _spanning_parameters(**parameters: list) -> list[dict]:
 class AbstractTestAbstractAperture(
     test_mixins.AbstractTestDxfWritable,
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestPlottable,
     test_mixins.AbstractTestTransformable,
     test_mixins.AbstractTestShaped,

--- a/optika/chemicals/_chemicals.py
+++ b/optika/chemicals/_chemicals.py
@@ -16,6 +16,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractChemical(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/chemicals/_tests/test_chemicals.py
+++ b/optika/chemicals/_tests/test_chemicals.py
@@ -16,6 +16,7 @@ _wavelength = [
 
 class AbstractTestAbstractChemical(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
     abc.ABC,
 ):

--- a/optika/distortion/_distortion.py
+++ b/optika/distortion/_distortion.py
@@ -24,6 +24,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractDistortionModel(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/distortion/_distortion_test.py
+++ b/optika/distortion/_distortion_test.py
@@ -22,6 +22,7 @@ def _scene() -> na.SpectralPositionalVectorArray:
 
 class AbstractTestAbstractDistortionModel(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_distort(self, a: optika.distortion.AbstractDistortionModel):

--- a/optika/materials/_layers.py
+++ b/optika/materials/_layers.py
@@ -22,6 +22,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractLayer(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
     abc.ABC,
 ):

--- a/optika/materials/_materials.py
+++ b/optika/materials/_materials.py
@@ -20,6 +20,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractMaterial(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,
 ):

--- a/optika/materials/_tests/test_meshes.py
+++ b/optika/materials/_tests/test_meshes.py
@@ -6,6 +6,7 @@ from optika._tests import test_mixins
 
 class AbstractTestAbstractMesh(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_chemical(self, a: optika.materials.meshes.AbstractMesh):

--- a/optika/materials/_tests/test_profiles.py
+++ b/optika/materials/_tests/test_profiles.py
@@ -8,6 +8,7 @@ from optika._tests import test_mixins
 
 class AbstractTestAbstractInterfaceProfile(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_width(self, a: optika.materials.profiles.AbstractInterfaceProfile):

--- a/optika/materials/meshes.py
+++ b/optika/materials/meshes.py
@@ -18,6 +18,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractMesh(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/materials/profiles.py
+++ b/optika/materials/profiles.py
@@ -20,6 +20,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractInterfaceProfile(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/metrology/_roughness.py
+++ b/optika/metrology/_roughness.py
@@ -11,6 +11,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class RoughnessParameters(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """The parameters needed to compute the roughness of an optical surface."""

--- a/optika/metrology/_slope_error.py
+++ b/optika/metrology/_slope_error.py
@@ -11,6 +11,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class SlopeErrorParameters(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """The parameters needed to compute the slope error."""

--- a/optika/metrology/_tests/test_roughness.py
+++ b/optika/metrology/_tests/test_roughness.py
@@ -17,6 +17,7 @@ from optika._tests import test_mixins
 )
 class TestRoughnessParameters(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_period_min(self, a: optika.metrology.RoughnessParameters):

--- a/optika/metrology/_tests/test_slope_error.py
+++ b/optika/metrology/_tests/test_slope_error.py
@@ -17,6 +17,7 @@ from optika._tests import test_mixins
 )
 class TestSlopeErrorParameters(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_step_size(self, a: optika.metrology.SlopeErrorParameters):

--- a/optika/mixins.py
+++ b/optika/mixins.py
@@ -1,7 +1,7 @@
 """Mixin classes used throughout this package."""
 
 from __future__ import annotations
-from typing import Any
+from typing import Any, Self
 import abc
 import dataclasses
 import pathlib
@@ -15,6 +15,7 @@ from ezdxf.addons.r12writer import R12FastStreamWriter
 
 __all__ = [
     "Shaped",
+    "Replaceable",
     "Printable",
     "Plottable",
     "Transformable",
@@ -35,6 +36,61 @@ class Shaped(abc.ABC):
         """
         The array shape of this object.
         """
+
+
+@dataclasses.dataclass(repr=False)
+class Replaceable(abc.ABC):
+    """An object which can be copied with some of its fields changed."""
+
+    def replace(self, /, **changes) -> Self:
+        """
+        A copy of this object with the given fields replaced.
+
+        A method version of :func:`dataclasses.replace`, matching
+        :meth:`named_arrays.AbstractArray.replace`, so that a nested change
+        reads the same at every level:
+
+        .. code-block:: python
+
+            system.replace(
+                surface=system.surface.replace(
+                    sag=system.surface.sag.replace(radius=r),
+                ),
+            )
+
+        The copy is shallow, as :func:`dataclasses.replace` is: every field
+        which is not named is shared with the original, and mutating one
+        through the copy is mutating it in both. Take
+        :func:`copy.deepcopy` of the result where that matters.
+
+        Parameters
+        ----------
+        changes
+            The fields to overwrite in the copy.
+
+        Examples
+        --------
+        Move a surface without disturbing the one it was copied from.
+
+        .. jupyter-execute::
+
+            import astropy.units as u
+            import named_arrays as na
+            import optika
+
+            surface = optika.surfaces.Surface(
+                sag=optika.sags.SphericalSag(radius=100 * u.mm),
+            )
+
+            moved = surface.replace(
+                transformation=na.transformations.Cartesian3dTranslation(
+                    z=10 * u.mm,
+                ),
+            )
+
+            moved.transformation, surface.transformation
+        """
+        return dataclasses.replace(self, **changes)
 
 
 @dataclasses.dataclass(repr=False)

--- a/optika/radiometry/_effective_area.py
+++ b/optika/radiometry/_effective_area.py
@@ -12,6 +12,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractEffectiveAreaModel(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/radiometry/_effective_area_test.py
+++ b/optika/radiometry/_effective_area_test.py
@@ -16,6 +16,7 @@ def _area() -> na.AbstractScalar:
 
 class AbstractTestAbstractEffectiveAreaModel(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test__call__(self, a: optika.radiometry.AbstractEffectiveAreaModel):

--- a/optika/radiometry/_vignetting.py
+++ b/optika/radiometry/_vignetting.py
@@ -20,6 +20,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractVignettingModel(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/radiometry/_vignetting_test.py
+++ b/optika/radiometry/_vignetting_test.py
@@ -26,6 +26,7 @@ def _illumination() -> na.AbstractScalar:
 
 class AbstractTestAbstractVignettingModel(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test__call__(self, a: optika.radiometry.AbstractVignettingModel):

--- a/optika/rulings/_rulings.py
+++ b/optika/rulings/_rulings.py
@@ -131,6 +131,7 @@ def incident_effective(
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractRulings(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/rulings/_rulings_test.py
+++ b/optika/rulings/_rulings_test.py
@@ -11,6 +11,7 @@ _wavelength = na.linspace(100, 300, axis="wavelength", num=11) * u.AA
 
 class AbstractTestAbstractRulings(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_diffraction_order(self, a: optika.rulings.AbstractRulings):

--- a/optika/rulings/_spacing.py
+++ b/optika/rulings/_spacing.py
@@ -14,6 +14,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractRulingSpacing(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,
 ):

--- a/optika/rulings/_spacing_test.py
+++ b/optika/rulings/_spacing_test.py
@@ -8,6 +8,7 @@ from .._tests import test_mixins
 
 class AbstractTestAbstractRulingSpacing(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestTransformable,
     test_mixins.AbstractTestShaped,
 ):

--- a/optika/sags/_abc.py
+++ b/optika/sags/_abc.py
@@ -13,6 +13,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractSag(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,
     optika.propagators.AbstractRayPropagator,

--- a/optika/sags/_tests/_abc_test.py
+++ b/optika/sags/_tests/_abc_test.py
@@ -40,6 +40,7 @@ def radius_parameterization() -> list[u.Quantity | na.AbstractScalar]:
 
 class AbstractTestAbstractSag(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestTransformable,
     test_mixins.AbstractTestShaped,
     test_propagators.AbstractTestAbstractRayPropagator,

--- a/optika/sensors/materials/depletion/_depletion.py
+++ b/optika/sensors/materials/depletion/_depletion.py
@@ -15,6 +15,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractDepletionModel(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Shaped,
 ):
     """

--- a/optika/sensors/materials/depletion/_depletion_test.py
+++ b/optika/sensors/materials/depletion/_depletion_test.py
@@ -8,6 +8,7 @@ from optika._tests import test_mixins
 
 class AbstractTestAbstractDepletionModel(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestShaped,
 ):
     def test_thickness(

--- a/optika/surfaces.py
+++ b/optika/surfaces.py
@@ -47,6 +47,7 @@ class AbstractSurface(
     optika.mixins.DxfWritable,
     optika.mixins.Plottable,
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,
     optika.propagators.AbstractLightPropagator,

--- a/optika/systems/_systems.py
+++ b/optika/systems/_systems.py
@@ -14,6 +14,7 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractSystem(
     optika.mixins.Printable,
+    optika.mixins.Replaceable,
     optika.mixins.Transformable,
     optika.mixins.Shaped,
 ):

--- a/optika/systems/_systems_test.py
+++ b/optika/systems/_systems_test.py
@@ -8,6 +8,7 @@ from .._tests import test_mixins
 
 class AbstractTestAbstractSystem(
     test_mixins.AbstractTestPrintable,
+    test_mixins.AbstractTestReplaceable,
     test_mixins.AbstractTestTransformable,
     test_mixins.AbstractTestShaped,
 ):


### PR DESCRIPTION
`named_arrays.AbstractArray` has carried a `replace` method for a while, so a change to a named array reads as a method call while the same change to the object holding it needs `dataclasses.replace` wrapped around it. Nesting one inside the other reads unevenly:

```python
dataclasses.replace(
    surface,
    sag=surface.sag.replace(radius=r),
)
```

Every domain object here is a dataclass and can be replaced, so the mixin says so, and both levels read alike:

```python
surface.replace(sag=surface.sag.replace(radius=r))
```

## Where it came from

esis-mission/esis#80 focuses a grating by moving it along the optic axis, and does it with `copy.deepcopy` followed by `result.__dict__.pop("system", None)` to drop the cached raytrace. That second line is easy to leave out and fails silently when you do: the cached system is built at the old grating position, so the objective goes flat and the solver returns a focus offset that means nothing.

Building a new instance instead makes the problem disappear rather than needing to be remembered, since a new instance has no cache to invalidate. Doing that today would mix the two spellings at adjacent levels, hence this.

## What it does

```python
class Replaceable(abc.ABC):
    """An object which can be copied with some of its fields changed."""

    def replace(self, /, **changes) -> Self:
        return dataclasses.replace(self, **changes)
```

Added wherever `optika.mixins.Printable` already was, those being the same seventeen declarations, and those being exactly the domain dataclasses.

The docstring is explicit that **the copy is shallow**, since that is the part which bites: every field not named is shared with the original, and mutating one through the copy mutates it in both. That is the contract `dataclasses.replace` has always had, but it is worth writing where somebody will read it, next to the method they are about to call.

## Testing

`AbstractTestReplaceable` is wired in beside `AbstractTestPrintable`, so it runs against every concrete type rather than one sample: **524 cases**. It asserts

- replacing nothing gives a distinct copy,
- every field which was not named is carried **by reference**, which pins the shallow contract rather than leaving it implied,
- and a named field is the one thing which differs.

`pytest optika`: 18313 passed, 304 skipped, 17 xfailed. black and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYjDL98znSud1yFh9chnkP
