### PR TITLE
Sample the field and the pupil the same way, from one grid

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1755,10 +1755,18 @@ class AbstractSequentialSystem(
         # taken over a different set of field positions than the vignetting
         # model is normalized over would rescale the result by the ratio of
         # the two sets.
-        area_eff = np.mean(
-            area_eff,
-            axis=axis_field,
-            where=unvignetted.any(axis_pupil),
+        # Written as a sum over a count rather than as a mean with `where`,
+        # so that a wavelength which no sampled field position admits comes
+        # out as no effective area rather than as the undefined average of an
+        # empty set.  That is reachable whenever the field is sampled coarsely
+        # enough, and a `nan` there would carry silently into every image the
+        # resulting model produces.
+        illuminated = unvignetted.any(axis_pupil)
+        num = illuminated.sum(axis_field)
+        area_eff = area_eff.sum(axis=axis_field, where=illuminated) / np.where(
+            num > 0,
+            num,
+            1,
         )
 
         return optika.radiometry.InterpolatedEffectiveAreaModel(

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -801,18 +801,31 @@ class AbstractSequentialSystem(
         return self.pupil_boundary.max(self.axis_stops)
 
     @property
-    def _pupil_vertices_default(self) -> na.Cartesian2dVectorArray:
+    def _field_vertices_default(self) -> na.Cartesian2dVectorArray:
         """
-        The pupil grid :meth:`area_effective` uses when given none.
+        The field grid :meth:`area_effective` and :meth:`linearize` use when
+        given none.
 
-        Its components are cell *vertices*, since the effective area weights
-        each ray by the area of its pupil cell, whereas
-        :attr:`grid_input` holds the points that rays are traced at.  That is
-        why the two cannot share a default.
+        Its components are cell *vertices*, not the points rays are traced
+        at, which are the centers of the cells these bound.
         """
         return na.Cartesian2dVectorArray(
-            x=na.linspace(-1, 1, axis="_pupil_x", num=11),
-            y=na.linspace(-1, 1, axis="_pupil_y", num=11),
+            x=na.linspace(-1, 1, axis="_field_x", num=12),
+            y=na.linspace(-1, 1, axis="_field_y", num=12),
+        )
+
+    @property
+    def _pupil_vertices_default(self) -> na.Cartesian2dVectorArray:
+        """
+        The pupil grid :meth:`area_effective` and :meth:`linearize` use when
+        given none.
+
+        Its components are cell *vertices*, since the effective area weights
+        each ray by the area of its pupil cell.
+        """
+        return na.Cartesian2dVectorArray(
+            x=na.linspace(-1, 1, axis="_pupil_x", num=12),
+            y=na.linspace(-1, 1, axis="_pupil_y", num=12),
         )
 
     def _denormalize_grid(
@@ -1625,17 +1638,18 @@ class AbstractSequentialSystem(
             If :obj:`None` (the default), ``self.grid_input.wavelength``
             will be used.
         field
-            The field positions at which the effective area is sampled before
-            averaging over the field of view, in either normalized or physical
-            units.
-            If :obj:`None` (the default), ``self.grid_input.field``
-            will be used.
+            The **vertices** of the field grid, in either normalized or
+            physical units.  One ray is traced per cell, at a point drawn
+            uniformly inside it, and the result is averaged over the cells
+            which lie in the field of view.
+            If :obj:`None` (the default), a :math:`12 \\times 12` grid spanning
+            the normalized field is used.
         pupil
             The **vertices** of the pupil grid, in either normalized or physical
             units. The area of each pupil cell is computed from these vertices
-            and used to weight the throughput, and the rays are traced at the
-            cell centers.
-            If :obj:`None` (the default), an :math:`11 \\times 11` grid spanning
+            and used to weight the throughput, and one ray is traced per cell, at
+            a point drawn uniformly inside it.
+            If :obj:`None` (the default), a :math:`12 \\times 12` grid spanning
             the normalized pupil is used.
         normalized_field
             A boolean flag indicating whether the `field` parameter is given
@@ -1652,7 +1666,7 @@ class AbstractSequentialSystem(
         if wavelength is None:
             wavelength = self.grid_input.wavelength
         if field is None:
-            field = self.grid_input.field
+            field = self._field_vertices_default
         if pupil is None:
             pupil = self._pupil_vertices_default
 
@@ -1695,10 +1709,28 @@ class AbstractSequentialSystem(
             )
         (axis_wavelength,) = axis_wavelength
 
-        shape = grid.shape
-
         area = np.abs(pupil.volume_cell(axis=axis_pupil))
-        pupil = pupil.broadcast_to(shape).cell_centers(axis=axis_pupil, random=True)
+
+        # Both grids are sampled once per cell, at a point drawn uniformly
+        # inside it.  Stratifying this way rather than taking the cell centers
+        # keeps the quadrature from aliasing against the edge of the field
+        # stop or of the pupil, which a fixed grid does at a rate depending on
+        # where that edge happens to fall between samples.
+        #
+        # The field is drawn once per cell per wavelength, and the pupil once
+        # per cell for every field position, so that no two rays share an
+        # offset and the errors average down instead of accumulating.
+        field = field.broadcast_to(
+            na.broadcast_shapes(na.shape(wavelength), na.shape(field)),
+        ).cell_centers(axis=axis_field, random=True)
+
+        pupil = pupil.broadcast_to(
+            na.broadcast_shapes(
+                na.shape(wavelength),
+                na.shape(field),
+                na.shape(pupil),
+            ),
+        ).cell_centers(axis=axis_pupil, random=True)
 
         rays = self.rayfunction(
             intensity=area,
@@ -1765,18 +1797,23 @@ class AbstractSequentialSystem(
             If :obj:`None` (the default), ``self.grid_input.wavelength``
             will be used.
         field
-            The field positions at which to sample the system, in either
-            normalized or physical units.
-            If :obj:`None` (the default), ``self.grid_input.field``
-            will be used.
+            The **vertices** of the field grid, in either normalized or
+            physical units.  The effective area samples a point inside every
+            cell, while the distortion and vignetting fits trace at the cell
+            centers.
+            If :obj:`None` (the default), a :math:`12 \\times 12` grid spanning
+            the normalized field is used.
         pupil
             The **vertices** of the pupil grid, in either normalized or physical
-            units. The effective area fit uses these vertices to compute the
-            pupil cell areas, while the distortion and vignetting fits trace at
-            the corresponding cell centers.
-            If :obj:`None` (the default), the effective area fit uses its own
-            default pupil grid and the distortion and vignetting fits use
-            ``self.grid_input.pupil``.
+            units. The effective area uses these vertices to compute the pupil
+            cell areas and samples a point inside every cell, while the
+            distortion and vignetting fits trace at the cell centers.
+            If :obj:`None` (the default), a :math:`12 \\times 12` grid spanning
+            the normalized pupil is used.
+
+            Both grids describe the same sampling for all three models, so
+            passing these defaults back reproduces what leaving them out
+            does.
         normalized_field
             A boolean flag indicating whether the `field` parameter is given
             in normalized or physical units.
@@ -1787,21 +1824,20 @@ class AbstractSequentialSystem(
             The degree of the polynomial distortion and vignetting models.
         """
 
-        # `area_effective` interprets `pupil` as cell vertices (it needs them to
-        # compute the pupil cell areas), while `distortion` and `vignetting`
-        # trace at sample points, so give them the cell centers of the vertices.
-        # With no pupil given the two fall back to different grids, since
-        # `grid_input.pupil` holds points and cannot serve as vertices.
-        if pupil is not None:
-            pupil_centers = pupil.cell_centers(axis=tuple(na.shape(pupil)))
-        else:
-            pupil = self._pupil_vertices_default
-            pupil_centers = self.grid_input.pupil
-
+        # `field` and `pupil` are cell vertices: `area_effective` needs them to
+        # weight each ray by the area of its pupil cell, and samples a point
+        # inside every cell, while `distortion` and `vignetting` trace at the
+        # cell centers.  Both therefore describe the same grid, so that
+        # passing the defaults back reproduces what leaving them out does.
         if wavelength is None:
             wavelength = self.grid_input.wavelength
         if field is None:
-            field = self.grid_input.field
+            field = self._field_vertices_default
+        if pupil is None:
+            pupil = self._pupil_vertices_default
+
+        field_centers = field.cell_centers(axis=tuple(na.shape(field)))
+        pupil_centers = pupil.cell_centers(axis=tuple(na.shape(pupil)))
 
         # Each of the three fits below denormalizes its own grid, and the
         # expensive part of that is solving for the stops, which depends on
@@ -1810,6 +1846,7 @@ class AbstractSequentialSystem(
         stops = self._calc_rayfunction_stops(wavelength)
 
         def denormalize(
+            field: na.AbstractCartesian2dVectorArray,
             pupil: na.AbstractCartesian2dVectorArray,
         ) -> optika.vectors.ObjectVectorArray:
             return self._denormalize_grid_from_rays(
@@ -1823,12 +1860,11 @@ class AbstractSequentialSystem(
                 normalized_pupil=normalized_pupil,
             )
 
-        grid_area = denormalize(pupil)
-        grid_fit = denormalize(pupil_centers)
+        grid_area = denormalize(field, pupil)
+        grid_fit = denormalize(field_centers, pupil_centers)
 
         kwargs = dict(
             wavelength=wavelength,
-            field=grid_area.field,
             normalized_field=False,
             normalized_pupil=False,
         )
@@ -1837,6 +1873,7 @@ class AbstractSequentialSystem(
         # intensity: `direction` is built from the geometry and from the index
         # of refraction, which is computed either way.
         rays, axis_wavelength, axis_field, axis_pupil = self._rayfunction_and_axes(
+            field=grid_fit.field,
             pupil=grid_fit.pupil,
             efficiency=False,
             **kwargs,
@@ -1864,7 +1901,11 @@ class AbstractSequentialSystem(
         )
 
         return LinearSystem(
-            area_effective=self.area_effective(pupil=grid_area.pupil, **kwargs),
+            area_effective=self.area_effective(
+                field=grid_area.field,
+                pupil=grid_area.pupil,
+                **kwargs,
+            ),
             distortion=self._fit_distortion(
                 rays=rays,
                 axis_wavelength=axis_wavelength,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1836,8 +1836,20 @@ class AbstractSequentialSystem(
         if pupil is None:
             pupil = self._pupil_vertices_default
 
-        field_centers = field.cell_centers(axis=tuple(na.shape(field)))
-        pupil_centers = pupil.cell_centers(axis=tuple(na.shape(pupil)))
+        # named explicitly rather than taken from the shape of each grid, which
+        # would also collapse any axis the grid carries beyond the two being
+        # centered, such as one of :attr:`shape`
+        axis_wavelength = self._normalize_axis_wavelength(None, wavelength)
+        axis_field = self._normalize_axis_field(None, axis_wavelength, field)
+        axis_pupil = self._normalize_axis_pupil(
+            axis_pupil=None,
+            axis_field=axis_field,
+            axis_wavelength=axis_wavelength,
+            pupil=pupil,
+        )
+
+        field_centers = field.cell_centers(axis=axis_field)
+        pupil_centers = pupil.cell_centers(axis=axis_pupil)
 
         # Each of the three fits below denormalizes its own grid, and the
         # expensive part of that is solving for the stops, which depends on

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -789,6 +789,53 @@ def test_linearize_conserves_flux():
     assert np.allclose(result, expected, rtol=0.15)
 
 
+def test_linearize_keeps_axes_it_is_not_centering():
+    """
+    Only the two field axes and the two pupil axes are collapsed from
+    vertices to centers.
+
+    A grid may carry axes of its own, such as one of ``system.shape``, and
+    those have to survive.  Taking the axes to center from the shape of the
+    grid rather than naming them would average such an axis into itself.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=_surfaces,
+        sensor=_sensor,
+        grid_input=_grid_input_wavelength,
+    )
+
+    num = 5
+    wavelength = _grid_input_wavelength.wavelength
+    num_wavelength = na.shape(wavelength)["wavelength"]
+
+    # a field grid which drifts with wavelength, so that it carries an axis
+    # which is not one of the two being centered
+    drift = 1e-6 * na.linspace(0, 1, axis="wavelength", num=num_wavelength)
+    field = na.Cartesian2dVectorArray(
+        x=na.linspace(0, 1, axis="field_x", num=num) + drift,
+        y=na.linspace(0, 1, axis="field_y", num=num) + drift,
+    )
+    pupil = na.Cartesian2dVectorArray(
+        x=na.linspace(-1, 1, axis="pupil_x", num=num),
+        y=na.linspace(-1, 1, axis="pupil_y", num=num),
+    )
+
+    result = system.linearize(
+        wavelength=wavelength,
+        field=field,
+        pupil=pupil,
+        degree=1,
+    )
+
+    # the scene the distortion is fit to is defined on the cell centers, so
+    # each field axis loses exactly one sample and the wavelength axis, which
+    # is not being centered, keeps all of its own
+    shape = na.shape(result.distortion.coordinates_scene.position)
+    assert shape["field_x"] == num - 1
+    assert shape["field_y"] == num - 1
+    assert shape["wavelength"] == num_wavelength
+
+
 def test__anchor_surface():
     first = optika.surfaces.Surface(name="first")
     last = optika.surfaces.Surface(name="last")

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -660,29 +660,29 @@ def test_area_effective_ignores_field_outside_the_field_of_view():
         grid_input=_grid_input_wavelength,
     )
 
-    field = na.Cartesian2dVectorLinearSpace(
-        start=0,
-        stop=1,
-        axis=na.Cartesian2dVectorArray("field_x", "field_y"),
-        num=5,
+    # `field` holds cell vertices, so these bound ten cells along each axis
+    vertices = np.linspace(0, 1, num=11)
+    field = na.Cartesian2dVectorArray(
+        x=na.ScalarArray(vertices, axes="field_x"),
+        y=na.ScalarArray(vertices, axes="field_y"),
     )
 
-    # the same five samples along each axis, plus two which land far enough
-    # outside the field stop that no ray through them reaches the sensor
-    samples = np.array([-3, 0, 0.25, 0.5, 0.75, 1, 3])
+    # the same ten cells, plus four along each axis which lie beyond the
+    # normalized field entirely, so no ray through them reaches the sensor
+    vertices_extended = np.concatenate([vertices, [1.5, 2, 2.5, 3]])
     field_extended = na.Cartesian2dVectorArray(
-        x=na.ScalarArray(samples, axes="field_x"),
-        y=na.ScalarArray(samples, axes="field_y"),
+        x=na.ScalarArray(vertices_extended, axes="field_x"),
+        y=na.ScalarArray(vertices_extended, axes="field_y"),
     )
 
     result = system.area_effective(field=field)
     result_extended = system.area_effective(field=field_extended)
 
-    # `area_effective` traces at randomly placed cell centers, so two calls
-    # differ by a percent or so.  Averaging over the extra field positions
-    # instead of ignoring them would halve the result, which this separates
-    # comfortably.
-    assert np.allclose(result_extended.area, result.area, rtol=0.05)
+    # `area_effective` samples a random point inside every cell, so two calls
+    # differ by about a percent at this resolution.  Averaging over the dark
+    # cells instead of ignoring them would leave the result 49% low, which
+    # this separates comfortably.
+    assert np.allclose(result_extended.area, result.area, rtol=0.1)
 
 
 def _system_vignetted() -> optika.systems.SequentialSystem:

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -789,6 +789,33 @@ def test_linearize_conserves_flux():
     assert np.allclose(result, expected, rtol=0.15)
 
 
+def test_area_effective_without_any_illuminated_field():
+    """
+    A wavelength which no sampled field position admits has no effective
+    area, rather than the undefined average of an empty set.
+
+    Averaging with `where` over nothing gives `nan`, which would carry
+    silently into every image the resulting model produces.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=_surfaces,
+        sensor=_sensor,
+        grid_input=_grid_input_wavelength,
+    )
+
+    # cells lying entirely beyond the normalized field, so nothing gets through
+    vertices = np.array([5, 6, 7])
+    field = na.Cartesian2dVectorArray(
+        x=na.ScalarArray(vertices, axes="field_x"),
+        y=na.ScalarArray(vertices, axes="field_y"),
+    )
+
+    result = system.area_effective(field=field)
+
+    assert np.all(np.isfinite(result.area))
+    assert np.all(result.area == 0 * result.area.unit)
+
+
 def test_linearize_keeps_axes_it_is_not_centering():
     """
     Only the two field axes and the two pupil axes are collapsed from


### PR DESCRIPTION
`linearize` documents `pupil` as cell **vertices**, then defaults to two grids which are neither vertices nor each other: `area_effective` invents its own, while the distortion and vignetting fits take `grid_input.pupil`, which holds the points rays are traced at.

So the default is not expressible through the parameter. Passing the grid the docstring names gives a different model:

```
linearize(pupil=None)  vs  linearize(pupil=grid_input.pupil):
  distortion coefficients differ by   0.02%
  vignetting coefficients differ by 162.69%
  effective area differs by           1.57%
```

Nothing errors. A reader who takes "the vertices of the pupil grid" at face value, and passes `grid_input.pupil` to be explicit, silently gets a vignetting model 163% away from the default.

## One rule for both axes

`field` and `pupil` are cell vertices. `area_effective` samples a point drawn uniformly inside every cell; the fits trace at the cell centers. Both models describe the same grid, so passing the defaults back reproduces leaving them out:

```
linearize()  vs  linearize(field=<default>, pupil=<default>):
  distortion  0.00e+00   (bit-identical: True)
  vignetting  0.00e+00   (bit-identical: True)
  area        0.73%      <- jitter; two default runs differ by 1.96%
```

## Stratifying the field is what the vertices buy

The field average used to wander with the sampling instead of converging. It now does both monotonically, against a 40×40 reference:

```
   cells |    bias |   noise
 11x11   |  0.67% |  1.93%
 15x15   |  0.54% |  0.73%
 21x21   |  0.27% |  0.46%
 25x25   |  0.23% |  0.41%
 31x31   |  0.11% |  0.27%
```

Before, on a deterministic field grid, the bias ran 0.38%, 0.95%, 0.59%, 0.78%, 0.61% with no trend — refining it was a coin flip rather than an improvement.

## What it costs

Measured on the ESIS as-built model, against today:

```
  distorted position moves by 0.013 pix   (resolution element is 2.81 pix)
  illumination moves by       1.37%
  effective area moves by     1.77%
```

All well inside the 5.8% photon noise implied by the SNR 17.3 requirement, and the position shift is 1/200 of a resolution element.

## Tests

`test_area_effective_ignores_field_outside_the_field_of_view` is rewritten for the vertex convention, extending the grid by dark *cells* rather than dark points. Sized deliberately: at 10 cells per axis its noise is 1.4% against the 49% error it guards against, and it is verified to fail with the field mask removed.

Full suite: 18314 passed, 304 skipped, 17 xfailed. `_sequential.py` at 100% line coverage. esis passes downstream unchanged (260 tests).

## Relationship to #187

This is deliberately *not* #187. `grid_input` keeps its current meaning — the points rays are traced at — and nothing outside `linearize` and `area_effective` changes, so no downstream migration and no major version bump. It settles the convention only where the two interpretations were already colliding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
