### PR TITLE
Let the sampling of the field and the pupil be seeded

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1138,6 +1138,7 @@ class AbstractSequentialSystem(
         axis_pupil: tuple[str, str],
         normalized_field: bool = True,
         normalized_pupil: bool = True,
+        seed: None | int = None,
     ) -> optika.rays.RayFunctionArray:
         """
         Similar to :meth:`rayfunction` except that the wavelength, field, and
@@ -1194,6 +1195,7 @@ class AbstractSequentialSystem(
         grid_centered = grid.broadcast_to(shape).cell_centers(
             axis=(axis_wavelength,) + axis_field + axis_pupil,
             random=True,
+            seed=seed,
         )
 
         area = grid.cell_area(
@@ -1595,6 +1597,7 @@ class AbstractSequentialSystem(
         pupil: None | na.AbstractCartesian2dVectorArray = None,
         normalized_field: bool = True,
         normalized_pupil: bool = True,
+        seed: None | int = None,
     ) -> optika.radiometry.InterpolatedEffectiveAreaModel:
         """
         Estimate the wavelength-dependent effective area of this system by
@@ -1657,6 +1660,12 @@ class AbstractSequentialSystem(
         normalized_pupil
             A boolean flag indicating whether the `pupil` parameter is given
             in normalized or physical units.
+        seed
+            The seed of the sampling described above.
+            If :obj:`None` (the default), the sampling differs from one call
+            to the next, and so does the result: on the ESIS instrument two
+            calls give effective areas about two percent apart. Give a seed
+            to any quantity which is meant to be reproducible.
 
         Raises
         ------
@@ -1720,9 +1729,15 @@ class AbstractSequentialSystem(
         # The field is drawn once per cell per wavelength, and the pupil once
         # per cell for every field position, so that no two rays share an
         # offset and the errors average down instead of accumulating.
+        # The two grids are sampled from two streams rather than one, since
+        # a seed shared between them would offset a field cell and a pupil
+        # cell by the same fraction wherever the two grids happen to agree
+        # in shape.
+        seed_field, seed_pupil = np.random.SeedSequence(seed).generate_state(2)
+
         field = field.broadcast_to(
             na.broadcast_shapes(na.shape(wavelength), na.shape(field)),
-        ).cell_centers(axis=axis_field, random=True)
+        ).cell_centers(axis=axis_field, random=True, seed=int(seed_field))
 
         pupil = pupil.broadcast_to(
             na.broadcast_shapes(
@@ -1730,7 +1745,7 @@ class AbstractSequentialSystem(
                 na.shape(field),
                 na.shape(pupil),
             ),
-        ).cell_centers(axis=axis_pupil, random=True)
+        ).cell_centers(axis=axis_pupil, random=True, seed=int(seed_pupil))
 
         rays = self.rayfunction(
             intensity=area,

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1213,3 +1213,28 @@ def test_plot_rays_2d_is_a_line():
     assert rays
     for artist in rays:
         assert isinstance(artist, matplotlib.lines.Line2D)
+
+
+def test_area_effective_is_reproducible_when_seeded():
+    """
+    A seed fixes the sampling, and so fixes the answer.
+
+    The field and the pupil are sampled at a point drawn inside each cell,
+    which keeps the quadrature from aliasing against an edge but leaves the
+    result a little different on every call. Anything which must be
+    reproduced, such as a figure in an article, needs to be able to ask for
+    the same sample twice.
+    """
+    system = optika.systems.SequentialSystem(
+        surfaces=_surfaces,
+        sensor=_sensor,
+        grid_input=_grid_input_wavelength,
+    )
+    wavelength = _grid_input_wavelength.wavelength
+
+    a = system.area_effective(wavelength=wavelength, seed=42)(wavelength)
+    b = system.area_effective(wavelength=wavelength, seed=42)(wavelength)
+    c = system.area_effective(wavelength=wavelength, seed=43)(wavelength)
+
+    assert np.all(a == b)
+    assert np.any(a != c)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy!=6.1.5",
-    "named-arrays~=2.8",
+    "named-arrays~=2.9",
     "pymupdf",
     "joblib",
     "ezdxf",


### PR DESCRIPTION
`area_effective` samples the field and the pupil at a point drawn inside each cell rather than at its center, which is what #219 established: it keeps the quadrature from aliasing against an edge which falls between samples. Nothing could fix that sampling, so nothing computed through it could be reproduced.

Two calls on the ESIS model, nothing changed between them:

```
no seed          peaks 0.018716  0.018704   identical: False
```

About two percent apart, which is the same size as the effect #219 was measured against. An article which draws that curve draws a different one every time it is built, and a count rate computed from it moves with it.

## With a seed

```
same seed        peaks 0.018696  0.018696   identical: True
different seed   peaks 0.018696  0.018642   identical: False
```

## Two streams, not one

The field and the pupil are drawn from two seeds derived from the given one with `SeedSequence`, rather than both from the seed itself. Sharing it would offset a field cell and a pupil cell by the same fraction wherever the two grids agreed in shape — the same failure as giving every axis of one grid the same offset, which puts each sample on the diagonal of its cell instead of inside it. `named-arrays` guards the second case; this guards the first.

## The default

`None`, so the sampling draws as it does today and nothing computed now moves.

The alternative is a fixed default, which would make every result reproducible without being asked. That is arguably what this should be — the randomness is a quadrature technique rather than anything physical, and a user who wants a different realization can say so. It would shift every existing result once, by about the two percent above, so I have not made that choice here. Worth deciding deliberately.

## Requires

`named-arrays~=2.9`, which added the `seed` parameter to `cell_centers` (sun-data/named-arrays#230).