### PR TITLE
Exclude the object surface from the system transformation

### DIFF
--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -96,6 +96,12 @@ class AbstractSequentialSystem(
         """
         Concatenate :attr:`object` with :attr:`surfaces` into a single list of
         surfaces.
+
+        The object surface defines the reference frame of the system and so is
+        left untouched, while :attr:`transformation` is composed onto every
+        other surface. Setting :attr:`transformation` therefore repositions the
+        optics relative to a fixed object, instead of moving the object and the
+        optics together as a rigid whole.
         """
         obj = self.object
         if obj is not None:
@@ -105,11 +111,23 @@ class AbstractSequentialSystem(
             # none, so this is here for the sake of a subclass which does not
             result = []
 
-        result += list(self.surfaces)
+        surfaces = list(self.surfaces)
 
         sensor = self.sensor
         if sensor is not None:
-            result += [sensor]
+            surfaces += [sensor]
+
+        transformation = self.transformation
+        result += [
+            dataclasses.replace(
+                surface,
+                transformation=na.transformations.compose(
+                    transformation,
+                    surface.transformation,
+                ),
+            )
+            for surface in surfaces
+        ]
 
         if not any(s.is_field_stop for s in result):
             result[0] = dataclasses.replace(result[0], is_field_stop=True)
@@ -689,9 +707,6 @@ class AbstractSequentialSystem(
         result.outputs.position = result.outputs.position.broadcast_to(shape)
         result.outputs.direction = result.outputs.direction.broadcast_to(shape)
 
-        if self.transformation is not None:
-            result.outputs = self.transformation(result.outputs)
-
         return result
 
     axis_pupil_stop: ClassVar[str] = "_stop_pupil"
@@ -1021,8 +1036,6 @@ class AbstractSequentialSystem(
         rays = result.outputs
         if intensity is not None:
             rays.intensity = intensity
-        if self.transformation is not None:
-            rays = self.transformation.inverse(rays)
 
         surfaces = self.surfaces_all
 
@@ -2083,15 +2096,11 @@ class AbstractSequentialSystem(
         """
 
         surfaces = self.surfaces_all
-        transformation_self = self.transformation
         kwargs_plot = self.kwargs_plot
 
-        if transformation is not None:
-            if transformation_self is not None:
-                transformation = transformation @ transformation_self
-        else:
-            transformation = transformation_self
-
+        # `surfaces_all` already carries `self.transformation` on the optics,
+        # so only the caller's transformation is applied here on top of each
+        # surface's own placement.
         if kwargs_plot is not None:
             kwargs = kwargs | kwargs_plot
 
@@ -2279,12 +2288,9 @@ class AbstractSequentialSystem(
         **kwargs,
     ) -> None:
 
-        if self.transformation is not None:
-            if transformation is not None:
-                transformation = transformation @ self.transformation
-            else:
-                transformation = self.transformation
-
+        # `surfaces_all` already carries `self.transformation` on the optics,
+        # so only the caller's transformation is applied here on top of each
+        # surface's own placement.
         surfaces = self.surfaces_all
 
         for surface in surfaces:

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -529,7 +529,7 @@ _objects = [
 _transformations = [
     None,
     None,
-    na.transformations.Cartesian3dTranslation(x=100 * u.mm),
+    na.transformations.Cartesian3dTranslation(x=1 * u.mm),
     na.transformations.Cartesian3dRotationZ(23 * u.deg),
 ]
 
@@ -612,6 +612,37 @@ _grid_input_wavelength = optika.vectors.ObjectVectorArray(
 )
 class TestSequentialSystem(AbstractTestAbstractSequentialSystem):
     pass
+
+
+def test_transformation_moves_optics_not_object():
+    """
+    The system transformation repositions the optics relative to a fixed
+    object, so it changes the raytrace instead of being a rigid relabel of the
+    whole system that leaves the image unmoved.
+    """
+    base = _system_newtonian
+    shift = 10 * u.mm
+    moved = dataclasses.replace(
+        base,
+        transformation=na.transformations.Cartesian3dTranslation(x=shift),
+    )
+
+    axis = base.axis_surface
+    kwargs = dict(
+        wavelength=500 * u.nm,
+        field=na.Cartesian2dVectorArray(0, 0),
+        pupil=na.Cartesian2dVectorArray(0, 0),
+        accumulate=True,
+    )
+    sensor_x_base = base.raytrace(**kwargs).outputs.position[{axis: ~0}].x
+    sensor_x_moved = moved.raytrace(**kwargs).outputs.position[{axis: ~0}].x
+
+    # the image moves with the optics by the amount of the system translation
+    assert not np.allclose(sensor_x_base.ndarray, sensor_x_moved.ndarray)
+    assert np.allclose((sensor_x_moved - sensor_x_base).ndarray, shift)
+
+    # the object surface is left in its own frame, untouched by the transform
+    assert moved.surfaces_all[0].transformation == base.surfaces_all[0].transformation
 
 
 @dataclasses.dataclass(eq=False, repr=False)


### PR DESCRIPTION
## Motivation

`SequentialSystem.transformation` was applied to the *whole* system, the object surface included. Because the object is where rays originate, transforming it along with the optics is a rigid relabel of the coordinate frame: it cancels out of the raytrace entirely and has **no effect on the imaging**.

A quick check on `main`: translating a system by 100 mm in `x` leaves the traced image unchanged, while translating a single optic's own transformation by the same amount moves it as expected. So `system.transformation` could only redraw the instrument (plot/DXF), never model a repositioned or perturbed one.

Conceptually the object represents the external scene (for our instruments, the Sun), not part of the instrument. Pointing an instrument moves the optics; the scene stays fixed. This PR makes `system.transformation` mean exactly that.

## Change

- `surfaces_all` now composes `self.transformation` onto the non-object surfaces only, leaving the object as the fixed reference frame. This becomes the single place the transform is applied.
- Removed the two ray-level applications that only relabeled-and-cancelled: the output of `_calc_rayfunction_stops` and the input inverse in `raytrace`.
- `plot` and `_write_to_dxf` no longer re-apply `self.transformation` on top of the surfaces (which already carry it), so the optics aren't double-transformed and the object isn't moved.

Systems that do not set `transformation` are unaffected (`compose(None, x) is x`, and the removed blocks were `if not None` guards).

## Consequence

The world/global coordinate frame of a system is now its object frame: `raytrace`, `field_boundary`, and `pupil_boundary` come out in the object frame, with the instrument placed into it by `transformation`. Figure-level placement is unchanged, since `plot()` still takes its own `transformation` argument.

## Tests

- Added `test_transformation_moves_optics_not_object`: a system translation moves the image with the optics while the object stays put.
- Shrank one test fixture's system translation (`x=100mm` -> `x=1mm`) so it remains imaging-preserving under the new semantics (100 mm shoved the optics off a 10 mm object, producing an empty image — the correct new behavior, but no longer a useful `test_image` fixture).

Full `optika/systems` suite passes (`spot_diagram` failures under `MPLBACKEND=agg` are pre-existing and reproduce on `main`).

Depends only on `na.transformations.compose`, already released in `named-arrays` 2.9.0 (optika requires `~=2.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc