### PR TITLE
Denormalize the entrance pupil per field point, and measure every result in the system's own frame

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,17 @@ Jupyter notebook examples on how to use :mod:`optika`.
     tutorials/prime_focus
 
 
+Topic Guides
+============
+
+Longer descriptions of how parts of :mod:`optika` work.
+
+.. toctree::
+    :maxdepth: 1
+
+    stop_finding
+
+
 API Reference
 =============
 

--- a/docs/stop_finding.rst
+++ b/docs/stop_finding.rst
@@ -1,0 +1,381 @@
+Stop Finding
+============
+
+One of the design goals of :mod:`optika` is to automatically compute the
+field of view and entrance pupil of an optical system (see
+:attr:`~optika.systems.AbstractSequentialSystem.field_min`,
+:attr:`~optika.systems.AbstractSequentialSystem.field_max`,
+:attr:`~optika.systems.AbstractSequentialSystem.pupil_min`, and
+:attr:`~optika.systems.AbstractSequentialSystem.pupil_max`).
+Unlike Zemax, the user never has to specify the extent of the field or pupil.
+This page describes the strategy :mod:`optika` uses to discover that extent and
+to sample the field and pupil for imaging, since the strategy spans several
+methods and the reasoning behind it is easy to lose.
+
+
+Overview
+--------
+
+The trajectory of a ray through a sequential system is fixed by two surfaces:
+
+* the **field stop**, which limits the region of the object that is imaged, and
+* the **pupil stop** (or aperture stop), which limits the bundle of rays
+  accepted from each point of the object.
+
+A surface is marked as a stop by setting ``is_field_stop=True`` or
+``is_pupil_stop=True`` on it. Every ray that survives the system passes inside
+both stops, so a ray that grazes the *border* of one stop while passing through
+a chosen point of the other traces out the boundary of the accepted light. This
+is what :attr:`~optika.systems.AbstractSequentialSystem.rayfunction_stops`
+returns: a :class:`~optika.rays.RayFunctionArray`, defined on the first surface
+of the system, whose rays are constructed to strike prescribed points on both
+the field stop and the pupil stop. The field of view, the entrance pupil, and
+the sampling of rays used for image simulation are all derived from it.
+
+The difficulty is that a ray is launched from the *first* surface, but the
+constraints live on the *stop* surfaces further downstream. There is no
+closed-form expression for the launch coordinate that lands a ray on a given
+point of a given stop, so the launch coordinate is found by root-finding.
+
+
+Two principles
+--------------
+
+Everything below follows from two physical requirements. They are worth stating
+up front because they dictate *where* each coordinate is measured, and getting
+the measurement plane wrong produces answers that look plausible but are subtly
+biased.
+
+**The field is anchored on the object plane.**
+    A point-spread function is the image of a single point of the object. For
+    the simulated PSF to be correct, every ray in a given field bundle must
+    share one object direction (for a distant object) or one object position
+    (for a nearby object). If the field were instead anchored on an internal
+    surface, rays with the same field label but different pupil labels would
+    correspond to slightly different object points, smearing the PSF. So the
+    field coordinate is always resolved on the object plane.
+
+**The pupil is measured at the entrance pupil.**
+    The entrance pupil is the image of the pupil stop in object space, i.e. the
+    plane on which the incoming wavefront is uniform for a uniform distant
+    source. Measuring and sampling the pupil *there*, rather than on the
+    angular object plane or on the pupil stop itself, matters for two reasons:
+
+    * **Robustness.** For a system with a tiny entrance aperture (a feed optic
+      much smaller than the beam, as in FURST), the entrance-pupil extent is
+      essentially independent of field, so rays aimed through it always land on
+      the aperture. Measured instead as an angle on the object plane, the same
+      extent swings with field and a single global box makes most field angles
+      miss the aperture.
+
+    * **Radiometry.** Vignetting is the fraction of the accepted bundle that
+      survives to the detector, an area integral over the pupil. Sampling
+      uniformly on the entrance pupil is equal-area sampling in the plane where
+      the wavefront is uniform, so the vignetting fraction is an unweighted mean
+      of the surviving samples. Sampling uniformly on the pupil stop instead
+      would, for a system with pupil distortion (such as the grating in ESIS,
+      which is the pupil stop), place unequal areas of the entrance pupil under
+      each sample and bias the result.
+
+The consequence is that the field is resolved as an object-space coordinate and
+the pupil as an entrance-pupil coordinate, and the machinery below exists to
+connect those object-space coordinates to the physical stop surfaces.
+
+
+Input coordinates
+-----------------
+
+A stop ray is labelled by three input coordinates, gathered together in an
+:class:`~optika.vectors.ObjectVectorArray`:
+
+``wavelength``
+    The vacuum wavelength of the ray. It is carried through the solve
+    unchanged; it only matters because dispersive surfaces (gratings) bend
+    different wavelengths differently.
+
+``field``
+    A two-dimensional coordinate locating the ray on the field stop.
+
+``pupil``
+    A two-dimensional coordinate locating the ray on the pupil stop.
+
+Both ``field`` and ``pupil`` may be given in either **normalized** or
+**physical** units, and the units alone tell :mod:`optika` how to interpret
+them:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 25 25 50
+
+    * - Units
+      - Meaning
+      - Interpretation
+    * - dimensionless
+      - normalized
+      - A value in :math:`[-1, 1]`, denormalized against the bounding box of
+        the relevant stop's aperture.
+    * - length (e.g. ``mm``)
+      - physical position
+      - A position on the relevant surface.
+    * - angle (e.g. ``deg``)
+      - physical direction
+      - A direction, converted to direction cosines with
+        :func:`~optika.direction`.
+
+This convention (dimensionless means normalized, length means position, angle
+means direction) is used consistently throughout the stop-finding code; see
+``_coordinates_are_normalized`` and
+:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity`.
+
+
+The two-point ray solve
+-----------------------
+
+The core primitive is the private method ``_solve_rays``. Given a
+``subsystem`` (a contiguous slice of the system's surfaces), a wavelength, a
+grid ``grid_first`` on the first surface, and a grid ``grid_last`` on the last
+surface, it finds the launch ray that connects them. Both grids are given in
+*physical* units; denormalizing a normalized stop coordinate against its
+aperture is the caller's job, so at this boundary a dimensionless grid is an
+unambiguous direction cosine rather than a normalized coordinate.
+
+A ray leaving the first surface has two degrees of freedom that are *not*
+pinned by ``grid_first``. If ``grid_first`` is a **position**, the free degrees
+of freedom are the launch **direction**; if ``grid_first`` is a **direction**,
+they are the launch **position**. ``_solve_rays`` reads which case applies from
+the units of ``grid_first`` (length means position, angle or dimensionless
+direction cosine means direction), builds a
+:class:`~optika.rays.RayVectorArray` with the fixed coordinate filled in, and
+solves for the free coordinate so that the ray lands on ``grid_last`` at the
+last surface. The residual whose root is sought is the miss distance at the
+last surface,
+
+.. math::
+
+    \vec{r}(\vec{a}) = \vec{g}_\text{trial}(\vec{a}) - \vec{g}_\text{last},
+
+where :math:`\vec{a}` is the trial value of the free coordinate and
+:math:`\vec{g}_\text{trial}` is where the resulting ray actually crosses the
+target coordinate of the last surface (its position if ``grid_last`` is a
+position, its direction if ``grid_last`` is a direction). This residual is
+evaluated by ``_ray_error`` and driven to zero with
+:func:`named_arrays.optimize.root_newton`.
+
+Because ``grid_last`` may itself be either a position or a direction, the same
+routine works in either direction along the system. In particular, running it
+with the subsystem reversed and an angular ``grid_last`` back-traces rays to a
+target *direction* on an object at infinity, which is how the field extent on
+the object plane is recovered.
+
+Two details make the solve robust across systems of wildly different physical
+scale:
+
+* **Seeding.** The initial guess aims each ray from the first surface toward a
+  sensible target: directly at its point on the last surface when no surface
+  with optical power lies in between (the guess is then nearly exact), and
+  otherwise at the center of the first powered surface (a mirror, a curved sag,
+  or a ruled surface, found by ``_anchor_surface``). This keeps the guess
+  inside the basin of convergence even for strongly off-axis feed or fold
+  mirrors.
+
+* **Scaling.** Both the convergence tolerance and the finite-difference step
+  used to estimate the Jacobian are scaled by the size of the target aperture,
+  so that a millimeter-scale spectrograph and a meter-scale telescope are
+  solved to the same *relative* precision. The default absolute step of
+  :func:`named_arrays.jacobian` is otherwise below the floating-point noise
+  floor of the raytrace and yields a Jacobian made of noise.
+
+``_solve_rays`` returns the launch rays *at the first surface* (in global
+coordinates), with both the given and the solved coordinate filled in, so that
+propagating them through the subsystem reproduces ``grid_last``.
+
+
+The strategy
+------------
+
+The two principles rule out computing a single global field box and a single
+global pupil box, because the entrance-pupil extent depends on field. Instead
+the field of view and the per-field entrance pupil are calibrated in stages,
+and the expensive root-finding is confined to a coarse grid.
+
+**1. Field extent on the object plane.**
+    A small number of rays connecting the field-stop border to the pupil-stop
+    border are traced back to the object plane, and their extent gives the
+    field of view. This is the object-plane field domain that every later stage
+    samples within.
+
+**2. Per-field entrance-pupil extent.**
+    The object surface is treated as the field stop, and a *coarse* grid of
+    field directions, sampled evenly across the field of view from stage 1, is
+    connected to every point on the *wire* (border) of the pupil stop with
+    ``_solve_rays``. Only the wire is needed: it is the boundary of the pupil
+    stop, so its image on the entrance pupil is the boundary of the entrance
+    pupil, and the minimum and maximum of those positions give a per-field
+    entrance-pupil bounding box. This is the stage that captures the
+    field dependence of the pupil (the pupil distortion), and it is the only
+    stage that pays for dense root-finding, kept affordable by using a coarse
+    field grid and only the one-dimensional pupil-stop wire.
+
+**3. Interpolation.**
+    The per-field bounding box from stage 2 is a smooth function of field (it is
+    the pupil distortion), so it is fit on the coarse field grid and
+    interpolated onto the dense field grid, in the same spirit as
+    :class:`~optika.distortion.PolynomialDistortionModel` and the vignetting
+    models. The coarse grid must be fine enough to resolve the distortion, not
+    the scene.
+
+**4. Dense forward trace.**
+    For image simulation, each dense ray is fully specified in object space: its
+    direction is an object-plane field angle, and its position is a normalized
+    pupil coordinate mapped onto the interpolated per-field entrance-pupil box.
+    Both coordinates are known without any root-finding, so the dense pass is a
+    pure *forward* trace through the system. This is what keeps a
+    :math:`1000 \times 1000` field affordable: the Newton solves live entirely
+    in the coarse calibration of stage 2, never in the dense grid.
+
+Because a uniform grid on the entrance-pupil box is equal-area in the plane
+where the wavefront is uniform, the vignetted fraction of that grid (with the
+``where`` keyword marking the surviving rays) is the vignetting directly, with
+no Jacobian weight. The axis-aligned bounding box slightly over-covers a
+rotated or astigmatic entrance pupil, but the excess samples fall outside the
+aperture and are removed by vignetting, so the result is correct if marginally
+less sample-efficient.
+
+
+The object as the field stop
+----------------------------
+
+Stage 2 relies on being able to mark the **object surface itself** as the field
+stop, with an angular (dimensionless, sine-of-half-angle) aperture. The
+``field`` coordinate is then a direction on the object plane rather than a
+position on an internal surface, which is exactly the object-plane anchoring the
+first principle requires. It is also the only workable option in two common
+cases where an internal field stop has no solution:
+
+* **Spectrographs**, where the field stop is the detector. A single wavelength
+  illuminates only part of the detector, so connecting the *border* of the
+  detector to the pupil stop has no solution at that wavelength.
+
+* **Systems with a tiny entrance aperture**, where a single global pupil box,
+  back-projected to the object, misses the feed optic for most field angles.
+
+When ``_solve_rays`` cannot connect an internal field stop at a single
+wavelength, the raised error points the user toward this option. Whether the
+object is treated as being at infinity is inferred from the units of its
+aperture: a length aperture is a finite object, a dimensionless aperture is an
+object at infinity (see
+:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity`).
+
+
+Field of view and entrance pupil
+--------------------------------
+
+The field of view and entrance pupil are read off from the stop rayfunction by
+reducing over *both* the field and pupil axes:
+
+* :attr:`~optika.systems.AbstractSequentialSystem.field_min` /
+  :attr:`~optika.systems.AbstractSequentialSystem.field_max` give the corners
+  of the field of view, expressed as angles (via :func:`~optika.angles`) when
+  the object is at infinity and as positions otherwise.
+
+* :attr:`~optika.systems.AbstractSequentialSystem.pupil_min` /
+  :attr:`~optika.systems.AbstractSequentialSystem.pupil_max` give the corners
+  of the entrance pupil, expressed as positions when the object is at infinity
+  and as angles otherwise.
+
+The two swap roles with object distance because field and pupil are conjugate:
+for a distant object the field is naturally angular and the pupil is a physical
+aperture, while for a nearby object the field is a physical extent and the
+pupil subtends an angle.
+
+
+The entrance pupil of each field point
+--------------------------------------
+
+The stop rayfunction gives one entrance pupil for the whole field: the box
+which every field point's pupil fits inside. That box is larger than any
+individual field point's pupil whenever the pupil walks across the field,
+which it does whenever the pupil stop is far from the entrance pupil. Rays
+drawn uniformly in it are then mostly outside the pupil of the field point
+they belong to, and are thrown away at the stop.
+
+:meth:`~optika.systems.AbstractSequentialSystem._calc_pupil_fit` calibrates the
+pupil per field point instead. It fits a quadratic in the field to the corners
+of the pupil, using the samples already present along the edge of the field
+stop plus one traced at the center of the field, and
+:meth:`~optika.systems.AbstractSequentialSystem._denormalize_grid` evaluates
+that fit at each field point being traced.
+
+Three things keep it honest:
+
+* The fitted box is clipped to the box shared by every field point, so a fit
+  which extrapolates cannot send rays outside the pupil the stops actually
+  admit.
+
+* Where the clipped box inverts, the shared box is used instead.
+
+* If the center of the field cannot be traced, or the fit is singular, the
+  whole calibration returns :obj:`None` and the shared box is used. This is
+  never worse than not having the fit at all.
+
+The fit is in the field alone; the wavelength rides along as a broadcast axis,
+since the fit is only ever evaluated at the wavelengths it was made at. It is
+cached on the system, along with the stop rays it is built from, because both
+depend on nothing but the wavelength.
+
+
+Conventions and assumptions
+---------------------------
+
+A few conventions are load-bearing and worth stating explicitly:
+
+* **Dimensionless means normalized at the system input, and a direction cosine
+  inside the solve.** A ``field`` or ``pupil`` grid supplied to the system is
+  interpreted as normalized when it is dimensionless (see the table above).
+  Denormalization happens before ``_solve_rays`` is called, so once inside the
+  solve a dimensionless grid is unambiguously a physical direction cosine.
+
+* **The pupil is measured in an object-space plane.** The entrance-pupil extent
+  and the sampling grid live on the entrance pupil, not on the pupil stop.
+  Measuring on the pupil stop would reintroduce the distortion bias the second
+  principle exists to avoid.
+
+* **Every grid and every set of rays belongs to a stated frame, and mixing two
+  of them is the most common way to get a wrong answer here.** Three
+  conventions are in play, and each is load-bearing:
+
+  * A grid produced by denormalizing an aperture is in **that surface's own
+    frame**, since an aperture and a sag are only defined there.
+
+  * ``_solve_rays`` takes its launch grid in the launch surface's frame and
+    returns the solved rays in the **global** frame, converting once at each
+    end.  Its ``aim`` argument is global.
+
+  * ``_calc_rayfunction_stops`` and ``_calc_rayfunction_pupil`` return their
+    rays in the **object surface's** frame, because that is the frame in which
+    ``_calc_rayfunction_input`` reads the field and pupil of the input grid.
+    The entrance pupil is fit from samples taken from both, so they have to
+    agree; a rotated object otherwise trains the fit on a center sample taken
+    at a different field point than its edge samples.
+
+  * :meth:`~optika.systems.AbstractSequentialSystem.rayfunction` returns its
+    rays in the **sensor's** frame, which is the sensor's own transformation
+    with the system's
+    :attr:`~optika.systems.SequentialSystem.transformation` composed on top,
+    since that is where ``surfaces_all`` places the sensor.  Its counterpart
+    :meth:`~optika.systems.AbstractSequentialSystem.raytrace` returns global
+    rays instead.
+
+  Nothing in the type system enforces any of this, so a function which takes
+  or returns rays should say which frame they are in.  What does enforce it is
+  ``test_rayfunction_is_invariant_under_a_rigid_motion``, which moves every
+  surface of a system together.  That describes the same instrument in a
+  different frame, so nothing the system reports may change; a quantity
+  measured in the global frame by mistake moves with the motion and fails.
+  Building a system at an angle on purpose does not test this, because tilting
+  one surface changes the instrument and can stop any light reaching the
+  sensor, which no amount of broken frame handling would then make worse.
+
+* **Angles are direction cosines.** :func:`~optika.direction` and
+  :func:`~optika.angles` convert between a pair of azimuth/elevation angles and
+  a three-dimensional direction cosine, and are inverses of each other.

--- a/docs/stop_finding.rst
+++ b/docs/stop_finding.rst
@@ -123,9 +123,11 @@ them:
         :func:`~optika.direction`.
 
 This convention (dimensionless means normalized, length means position, angle
-means direction) is used consistently throughout the stop-finding code; see
-``_coordinates_are_normalized`` and
-:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity`.
+means direction) is used consistently throughout the stop-finding code. There
+is no helper which decides it; each site tests the unit of the grid it was
+handed against :func:`~named_arrays.unit_normalized`, and reads
+:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity` to know
+which of position and direction the field is.
 
 
 The two-point ray solve
@@ -299,12 +301,11 @@ which it does whenever the pupil stop is far from the entrance pupil. Rays
 drawn uniformly in it are then mostly outside the pupil of the field point
 they belong to, and are thrown away at the stop.
 
-:meth:`~optika.systems.AbstractSequentialSystem._calc_pupil_fit` calibrates the
-pupil per field point instead. It fits a quadratic in the field to the corners
-of the pupil, using the samples already present along the edge of the field
-stop plus one traced at the center of the field, and
-:meth:`~optika.systems.AbstractSequentialSystem._denormalize_grid` evaluates
-that fit at each field point being traced.
+``_calc_pupil_fit`` calibrates the pupil per field point instead. It fits a
+quadratic in the field to the corners of the pupil, using the samples already
+present along the edge of the field stop plus one traced at the center of the
+field, and ``_denormalize_grid`` evaluates that fit at each field point being
+traced.
 
 Three things keep it honest:
 

--- a/optika/systems/__init__.py
+++ b/optika/systems/__init__.py
@@ -4,12 +4,13 @@ Optical systems consisting of multiple optical surfaces.
 
 from ._systems import AbstractSystem
 from ._linear import AbstractLinearSystem, LinearSystem
-from ._sequential import AbstractSequentialSystem, SequentialSystem
+from ._sequential import StopSolveError, AbstractSequentialSystem, SequentialSystem
 
 __all__ = [
     "AbstractSystem",
     "AbstractLinearSystem",
     "LinearSystem",
+    "StopSolveError",
     "AbstractSequentialSystem",
     "SequentialSystem",
 ]

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -888,8 +888,12 @@ class AbstractSequentialSystem(
         rayfunction_stops
             The stop rays at that wavelength.
         """
+        # The cache is only good for the stop rays it was built from.  A caller
+        # which solved its own stops, at a different number of wire samples
+        # say, must be given a fit which matches them.
         if self._wavelength_is_default(wavelength):
-            return self.pupil_fit
+            if rayfunction_stops is self.rayfunction_stops:
+                return self.pupil_fit
 
         return self._calc_pupil_fit(wavelength, rayfunction_stops)
 
@@ -1219,15 +1223,25 @@ class AbstractSequentialSystem(
         inputs = na.nominal(optika.vectors.SceneVectorArray(wavelength, field))
 
         def fit(outputs: na.AbstractCartesian2dVectorArray):
-            return na.PolynomialFitFunctionArray.from_degree(
+            result = na.PolynomialFitFunctionArray.from_degree(
                 inputs=inputs,
                 outputs=outputs,
                 degree=2,
                 components=("field.x", "field.y"),
                 axis_polynomial=axis_edge,
             )
+            # The least-squares solve is deferred until the coefficients are
+            # first read, which would put it outside this method and defeat
+            # the fallback below.  Force it here, so that a design matrix
+            # which turns out to be singular falls back to the shared box in
+            # the same way as a field center which cannot be traced.
+            result.coefficients
+            return result
 
-        return fit(pupil_min), fit(pupil_max)
+        try:
+            return fit(pupil_min), fit(pupil_max)
+        except ValueError:
+            return None
 
     def _denormalize_grid(
         self,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -805,6 +805,94 @@ class AbstractSequentialSystem(
         """
         return self._calc_rayfunction_stops(self.grid_input.wavelength)
 
+    def _wavelength_is_default(self, wavelength: na.ScalarLike) -> bool:
+        """
+        Whether the given wavelength is the one :attr:`grid_input` carries, and
+        so the one the cached stop rays and pupil calibration were solved at.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelength to compare against :attr:`grid_input`.
+        """
+        wavelength_default = self.grid_input.wavelength
+
+        if wavelength is wavelength_default:
+            return True
+
+        if na.shape(wavelength) != na.shape(wavelength_default):
+            return False
+
+        return bool(np.all(wavelength == wavelength_default))
+
+    def _rayfunction_stops(
+        self,
+        wavelength: na.ScalarLike,
+    ) -> optika.rays.RayFunctionArray:
+        """
+        The stop rays at the given wavelength, reusing
+        :attr:`rayfunction_stops` when that was solved at the same wavelength.
+
+        Solving for the stop rays is among the most expensive things this class
+        does, and denormalizing a grid needs them every time.  Most callers
+        denormalize against the system's own input wavelengths, which
+        :attr:`rayfunction_stops` has already solved for, so going through the
+        cache saves the whole solve.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelength to solve the stop rays at.
+        """
+        if self._wavelength_is_default(wavelength):
+            return self.rayfunction_stops
+
+        return self._calc_rayfunction_stops(wavelength)
+
+    @functools.cached_property
+    def pupil_fit(
+        self,
+    ) -> None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
+        """
+        The entrance pupil of the system, fit as a function of field position
+        at the wavelengths of :attr:`grid_input`.
+
+        :obj:`None` if the pupil could not be calibrated per field point, in
+        which case the box shared by every field point is used instead.
+
+        This property is cached to increase performance.
+        If :attr:`grid_input` is updated, the cache must be cleared with
+        ``del system.pupil_fit`` before calling this property.
+        """
+        wavelength = self.grid_input.wavelength
+        return self._calc_pupil_fit(wavelength, self._rayfunction_stops(wavelength))
+
+    def _pupil_fit(
+        self,
+        wavelength: na.ScalarLike,
+        rayfunction_stops: optika.rays.RayFunctionArray,
+    ) -> None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
+        """
+        The entrance pupil fit at the given wavelength, reusing
+        :attr:`pupil_fit` when that was solved at the same wavelength.
+
+        Calibrating the pupil traces the field edges and one field center for
+        every wavelength, which costs more than the rest of denormalizing a
+        grid put together.  It depends on nothing but the wavelengths, so a
+        caller working at the system's own input wavelengths pays for it once.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelength to calibrate the pupil at.
+        rayfunction_stops
+            The stop rays at that wavelength.
+        """
+        if self._wavelength_is_default(wavelength):
+            return self.pupil_fit
+
+        return self._calc_pupil_fit(wavelength, rayfunction_stops)
+
     @property
     def axis_stops(self) -> tuple[str, str]:
         """
@@ -1151,12 +1239,12 @@ class AbstractSequentialSystem(
         if (not normalized_field) and (not normalized_pupil):
             return grid
 
-        rayfunction_stops = self._calc_rayfunction_stops(grid.wavelength)
+        rayfunction_stops = self._rayfunction_stops(grid.wavelength)
 
         # the pupil is only calibrated when it needs denormalizing
         pupil_fit = None
         if normalized_pupil:
-            pupil_fit = self._calc_pupil_fit(grid.wavelength, rayfunction_stops)
+            pupil_fit = self._pupil_fit(grid.wavelength, rayfunction_stops)
 
         return self._denormalize_grid_from_rays(
             grid=grid,
@@ -2262,10 +2350,10 @@ class AbstractSequentialSystem(
         # entrance pupil, both of which depend on nothing but the wavelengths.
         # Solve once here and hand each of them a grid which is already
         # physical.
-        stops = self._calc_rayfunction_stops(wavelength)
+        stops = self._rayfunction_stops(wavelength)
         pupil_fit = None
         if normalized_pupil:
-            pupil_fit = self._calc_pupil_fit(wavelength, stops)
+            pupil_fit = self._pupil_fit(wavelength, stops)
 
         def denormalize(
             field: na.AbstractCartesian2dVectorArray,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -2174,6 +2174,63 @@ class AbstractSequentialSystem(
             where=where,
         )
 
+    @staticmethod
+    def _pupil_over_field_cells(
+        pupil: na.AbstractCartesian2dVectorArray,
+        axis_field: tuple[str, str],
+        axis_pupil: tuple[str, str],
+    ) -> na.AbstractCartesian2dVectorArray:
+        """
+        Bring a pupil grid given at the vertices of the field to its cells, as
+        the union of the boxes at each cell's vertices.
+
+        The pupil walks across the field, and once it is resolved per field
+        position its box is no larger than the pupil, so the box at the
+        center of a cell does not hold the pupil at the cell's edges. A ray
+        drawn anywhere in the cell must find its whole pupil inside the box
+        it is given, so the box for the cell is the smallest one holding the
+        boxes at all of the cell's vertices.
+
+        Parameters
+        ----------
+        pupil
+            The vertices of the pupil grid, carrying some or all of
+            `axis_field` at the resolution of the field vertices. Each field
+            vertex is assumed to carry the same normalized grid mapped
+            affinely onto its own box, which is how every grid this class
+            denormalizes is built.
+        axis_field
+            The axes of the field grid.
+        axis_pupil
+            The axes of the pupil grid.
+
+        Returns
+        -------
+            The pupil grid, carrying those field axes at the resolution of
+            the field cells. Field axes the grid does not carry are left
+            alone, and a grid carrying none is returned unchanged.
+        """
+        axis_field = tuple(ax for ax in axis_field if ax in na.shape(pupil))
+        if not axis_field:
+            return pupil
+
+        lo = pupil.min(axis_pupil)
+        hi = pupil.max(axis_pupil)
+
+        # the grid is affine in its box and the same at every field vertex,
+        # so any one vertex gives it back in normalized form; a box of no
+        # width in some component has no grid to recover along it
+        width = hi - lo
+        unit = na.unit_normalized(width.x)
+        safe = np.where(width > 0 * unit, width, 1 * unit)
+        normalized = ((pupil - lo) / safe)[{ax: 0 for ax in axis_field}]
+
+        for ax in axis_field:
+            lo = np.minimum(lo[{ax: slice(None, -1)}], lo[{ax: slice(1, None)}])
+            hi = np.maximum(hi[{ax: slice(None, -1)}], hi[{ax: slice(1, None)}])
+
+        return (hi - lo) * normalized + lo
+
     def area_effective(
         self,
         wavelength: None | u.Quantity | na.AbstractScalar = None,
@@ -2307,19 +2364,21 @@ class AbstractSequentialSystem(
             )
         (axis_wavelength,) = axis_wavelength
 
-        area = np.abs(pupil.volume_cell(axis=axis_pupil))
+        # The entrance pupil belongs to each field point, so the pupil grid
+        # carries the field axes at the resolution of the field vertices, and
+        # has to be brought to the field cells to line up with the field
+        # samples drawn below.  Not by averaging the vertices: the pupil
+        # walks across the field, so the box at the center of a cell clips
+        # the rays drawn toward the cell's edges by however far it walks
+        # across one cell.  On ESIS that is 2% of the pupil per cell of a
+        # 12 x 12 field, and it took half a percent off the effective area.
+        pupil = self._pupil_over_field_cells(
+            pupil=pupil,
+            axis_field=axis_field,
+            axis_pupil=axis_pupil,
+        )
 
-        # The entrance pupil belongs to each field point, so the pupil grid,
-        # and the area of its cells, carry the field axes at the resolution
-        # of the field vertices.  Bring them to the centers of the field
-        # cells here, to line up with the field samples drawn below.  The
-        # pupil walks smoothly across a single cell of the field, so its
-        # value at the center of the cell stands in for its value at the
-        # point drawn inside it.
-        axis_field_pupil = tuple(ax for ax in axis_field if ax in na.shape(pupil))
-        if axis_field_pupil:
-            area = area.cell_centers(axis=axis_field_pupil)
-            pupil = pupil.cell_centers(axis=axis_field_pupil)
+        area = np.abs(pupil.volume_cell(axis=axis_pupil))
 
         # Both grids are sampled once per cell, at a point drawn uniformly
         # inside it.  Stratifying this way rather than taking the cell centers

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1086,18 +1086,6 @@ class AbstractSequentialSystem(
             aim=aim,
         )
 
-        # The solver fixes the free component of each ray in the local
-        # coordinates of the launch surface, so a launch surface which is
-        # translated along the axis leaves the rays on the right lines but at
-        # the wrong depth.  Carry them to the launch surface itself, as the
-        # stops are, so that their positions are on the object where the
-        # entrance pupil is measured.
-        rays = optika.propagators.propagate_rays(
-            propagators=[subsystem[0]],
-            rays=rays,
-            efficiency=False,
-        )
-
         # `_calc_pupil_fit` fits these against samples taken from the stop
         # rays, which `_calc_rayfunction_stops` expresses in the object's own
         # coordinates.  Express these the same way, so that the two are
@@ -1183,8 +1171,13 @@ class AbstractSequentialSystem(
         pupil_min_edge = pupil.min(axis_wire)
         pupil_max_edge = pupil.max(axis_wire)
 
-        # one more sample at the center of the field, traced explicitly
-        field_center = field_edge.mean(axis_edge)
+        # One more sample at the center of the field, traced explicitly.
+        # The center is the middle of the field's extent and not the mean of
+        # these samples: the wire of an aperture closes, so its last point
+        # repeats its first, and averaging it leans toward that point by one
+        # part in `samples_field_stop`. That would make the sample the whole
+        # fit is anchored on depend on how finely the stop was sampled.
+        field_center = (field_edge.min(axis_edge) + field_edge.max(axis_edge)) / 2
         try:
             rays_center = self._calc_rayfunction_pupil(
                 wavelength=wavelength,
@@ -1377,7 +1370,12 @@ class AbstractSequentialSystem(
                 ) -> tuple[na.AbstractScalar, na.AbstractScalar]:
                     lo = np.maximum(lo, lo_global)
                     hi = np.minimum(hi, hi_global)
-                    bad = hi <= lo
+                    # Negate the healthy case rather than test for the
+                    # broken one, so that a corner which is not a number
+                    # falls back too. `hi <= lo` is false for a NaN, which
+                    # would let it through and turn every ray at that field
+                    # point into a NaN with nothing raised.
+                    bad = ~(hi > lo)
                     return np.where(bad, lo_global, lo), np.where(bad, hi_global, hi)
 
                 min_x, max_x = bound(fit_min.x, fit_max.x, global_min.x, global_max.x)

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1988,10 +1988,17 @@ class AbstractSequentialSystem(
         system.
 
         The relative illumination at each scene coordinate is estimated from
-        the fraction of unvignetted rays in the pupil, normalized so that its
+        the fraction of unvignetted rays in the pupil, weighted by how large
+        that field position's entrance pupil is, and normalized so that its
         average over the field of view is unity.
         Field points with no unvignetted rays are excluded from the fit and
         from the normalization.
+
+        The weight matters because the entrance pupil is resolved per field
+        position rather than shared, so two positions which pass the same
+        fraction of their own pupil need not collect the same light. Without
+        it this model and :meth:`area_effective` could not be multiplied
+        together except where every pupil happens to be the same size.
 
         Parameters
         ----------
@@ -2141,7 +2148,22 @@ class AbstractSequentialSystem(
         unvignetted = rays.outputs.unvignetted
         where = unvignetted.any(axis_pupil)
 
-        illumination = unvignetted.mean(axis_pupil)
+        # How much light a field position collects is the fraction of its
+        # entrance pupil which survives times how large that pupil is, and
+        # since the pupil is resolved per field position the second factor is
+        # not shared. :meth:`area_effective` weights by the area of each
+        # pupil cell and averages the product over the field, so leaving the
+        # size out here would leave the two models unable to be multiplied
+        # together, which is the whole point of fitting them.
+        #
+        # The size is the span of the sampled pupil, not the area of a cell,
+        # which is enough: one normalized pupil grid is shared by every field
+        # position and denormalizing maps it onto that position's pupil by an
+        # affine map, so the span is proportional to the pupil's area with a
+        # constant which divides out below.
+        span = rays.inputs.pupil.ptp(axis_pupil)
+
+        illumination = unvignetted.mean(axis_pupil) * span.x * span.y
         illumination = illumination / np.mean(
             illumination,
             axis=axis_field,
@@ -2182,9 +2204,14 @@ class AbstractSequentialSystem(
         which linearly interpolates in wavelength.
 
         The average is taken over the same field positions that
-        :meth:`vignetting` normalizes its illumination over, so that the two
-        models can be multiplied together to recover the effective area at a
-        given field position.
+        :meth:`vignetting` normalizes its illumination over, and that model
+        carries the size of each field position's entrance pupil, so that the
+        two can be multiplied together to recover the effective area at a
+        given field position.  Both halves of that are needed: an average over
+        one set of field positions and a normalization over another would
+        rescale the result by the ratio of the two, and an illumination which
+        left out the size of its pupil would be wrong wherever the pupil is
+        not the same size across the field.
 
         The components of `pupil` are interpreted as the vertices of a grid of
         cells, and the rays are traced at the corresponding cell centers, so

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -420,6 +420,215 @@ class AbstractSequentialSystem(
         result = grid_last_trial - grid_last
         return result
 
+    def _solve_rays(
+        self,
+        subsystem: list[optika.surfaces.AbstractSurface],
+        grid_first: na.AbstractCartesian2dVectorArray,
+        grid_last: na.AbstractCartesian2dVectorArray,
+        wavelength: na.ScalarLike,
+        aim: None | na.AbstractCartesian3dVectorArray = None,
+    ) -> optika.rays.RayVectorArray:
+        """
+        Solve for the rays launched from `grid_first` on the first surface of
+        `subsystem` which land on `grid_last` on its last surface.
+
+        Whichever component of the launch ray the grid on the first surface
+        does not fix is the free variable of the root-finding problem: a
+        physical grid (in units of length) fixes the launch position and the
+        direction is solved for, while an angular grid (dimensionless direction
+        cosines) fixes the launch direction and the position is solved for.
+
+        Parameters
+        ----------
+        subsystem
+            The consecutive surfaces to trace through, starting at the launch
+            surface and ending at the target surface.
+        grid_first
+            The launch grid, in the local coordinates of the first surface.
+        grid_last
+            The target grid, in the local coordinates of the last surface.
+        wavelength
+            The wavelength of the rays.
+        aim
+            The point, in global coordinates, to aim the initial guess of each
+            ray at.
+            If :obj:`None` (the default), each ray is aimed at its own target
+            point when no surface with optical power lies between the two
+            ends, and otherwise at the center of the first powered surface.
+
+        Returns
+        -------
+            The solved launch rays, in the global coordinates of the first
+            surface.
+        """
+        surface_first = subsystem[0]
+        surface_last = subsystem[~0]
+
+        rays = optika.rays.RayVectorArray(wavelength=wavelength)
+
+        if na.unit(grid_first).is_equivalent(u.mm):
+            grid_first = na.Cartesian3dVectorArray(
+                x=grid_first.x,
+                y=grid_first.y,
+                z=0 * u.mm,
+            )
+            rays.position = grid_first.replace(z=surface_first.sag(grid_first))
+            rays.direction = na.Cartesian3dVectorArray(0, 0, 1)
+            component_variable = "direction"
+
+            def zfunc(xy: na.AbstractCartesian2dVectorArray):
+                return np.sqrt(1 - np.square(xy.length))
+
+        elif na.unit(grid_first).is_equivalent(u.dimensionless_unscaled):
+            rays.direction = na.Cartesian3dVectorArray(
+                x=grid_first.x,
+                y=grid_first.y,
+                z=np.sqrt(1 - np.square(grid_first.length)),
+            )
+            rays.position = na.Cartesian3dVectorArray() * u.mm
+            component_variable = "position"
+
+            def zfunc(xy: na.AbstractCartesian2dVectorArray):
+                position = na.Cartesian3dVectorArray(
+                    x=xy.x,
+                    y=xy.y,
+                    z=0 * na.unit_normalized(xy.x),
+                )
+                return surface_first.sag(position)
+
+        else:  # pragma: nocover
+            raise ValueError(f"unrecognized input grid unit, {na.unit(grid_first)}")
+
+        # Seed the free ray component by aiming each ray at its own
+        # target point on the last surface when no surface with
+        # optical power lies between the two (the seed is then
+        # nearly exact), and otherwise at the center of the first powered
+        # surface, so that the root-finding starts inside its basin of
+        # convergence even for surfaces far from the axis of the first
+        # surface (e.g. an off-axis fold or feed mirror).
+        if aim is None:
+            anchor = self._anchor_surface(subsystem)
+            if anchor is surface_last and na.unit(grid_last).is_equivalent(u.mm):
+                aim = na.Cartesian3dVectorArray(
+                    x=grid_last.x,
+                    y=grid_last.y,
+                    z=0 * na.unit_normalized(grid_last.x),
+                )
+                aim.z = surface_last.sag(aim)
+                if surface_last.transformation is not None:
+                    aim = surface_last.transformation(aim)
+            else:
+                aim = na.Cartesian3dVectorArray() * u.mm
+                if anchor.transformation is not None:
+                    aim = anchor.transformation(aim)
+        if surface_first.transformation is not None:
+            aim = surface_first.transformation.inverse(aim)
+
+        if component_variable == "direction":
+            d = aim - rays.position
+            d = d / d.length
+            # the sign of the seed direction is irrelevant to the
+            # root-finding problem (surface intercepts may have negative
+            # distance), but the z-component must be positive to be
+            # consistent with `zfunc`
+            flip = np.sign(d.z)
+            where = d.z != 0
+            rays.direction = na.Cartesian3dVectorArray(
+                x=np.where(where, flip * d.x, 0),
+                y=np.where(where, flip * d.y, 0),
+                z=np.where(where, flip * d.z, 1),
+            )
+        else:
+            d = rays.direction
+            t = aim.z / d.z
+            position_seed = na.Cartesian3dVectorArray(
+                x=aim.x - d.x * t,
+                y=aim.y - d.y * t,
+                z=0 * u.mm,
+            )
+            position_seed.z = surface_first.sag(position_seed)
+            rays.position = position_seed
+
+        if surface_first.transformation is not None:
+            rays = surface_first.transformation(rays)
+
+        if na.unit(grid_last).is_equivalent(u.mm):
+            component_target = "position"
+        elif na.unit(grid_last).is_equivalent(u.dimensionless_unscaled):
+            component_target = "direction"
+        else:  # pragma: nocover
+            raise ValueError(f"unrecognized output grid unit, {na.unit(grid_last)}")
+
+        # The residual of the root-finding problem has the same units as
+        # the target grid, so the convergence tolerance must scale with
+        # the size of the target aperture to be achievable in floating
+        # point for systems of any physical scale.
+        scale = np.maximum(
+            grid_last.x.ptp(),
+            grid_last.y.ptp(),
+        )
+        max_abs_error = 1e-9 * np.maximum(
+            scale,
+            1 * na.unit_normalized(scale),
+        )
+
+        variables = getattr(rays, component_variable)
+
+        function = functools.partial(
+            self._ray_error,
+            rays=rays,
+            subsystem=subsystem,
+            grid_last=grid_last,
+            component_variable=component_variable,
+            component_target=component_target,
+            zfunc=zfunc,
+        )
+
+        # The default perturbation used by `na.jacobian` is an absolute
+        # 1e-10 in the units of the variable, which is below the
+        # floating-point noise floor of the raytrace for variables
+        # measured in physical units, yielding a Jacobian made of noise.
+        # Use a perturbation proportional to the scale of the problem
+        # instead.
+        if component_variable == "direction":
+            dx = 1e-6
+        else:
+            dx = 1e-6 * np.maximum(
+                scale,
+                1 * na.unit_normalized(scale),
+            )
+
+        def jacobian(x, _function=function, _dx=dx):
+            return na.jacobian(function=_function, x=x, dx=_dx)
+
+        try:
+            root = na.optimize.root_newton(
+                function=function,
+                guess=na.Cartesian2dVectorArray(
+                    x=variables.x,
+                    y=variables.y,
+                ),
+                jacobian=jacobian,
+                max_abs_error=max_abs_error,
+            )
+        except ValueError as e:  # pragma: nocover
+            raise ValueError(
+                f"Could not solve for the rays connecting the "
+                f"surfaces {surface_first.name!r} and "
+                f"{surface_last.name!r}. "
+                f"If the field stop is only partially reachable at a "
+                f"single wavelength (e.g. a spectrograph sensor), "
+                f"consider marking the object surface, with an angular "
+                f"(dimensionless, sine of the half-angle) aperture, as "
+                f"the field stop instead."
+            ) from e
+
+        variables.x = root.x
+        variables.y = root.y
+        variables.z = zfunc(root)
+
+        return rays
+
     def _calc_rayfunction_stops_only(
         self,
         wavelength_input: na.ScalarLike,
@@ -487,167 +696,12 @@ class AbstractSequentialSystem(
                 result.inputs.field = grid_first
                 result.inputs.pupil = grid_last
 
-            if na.unit(grid_first).is_equivalent(u.mm):
-                grid_first = na.Cartesian3dVectorArray(
-                    x=grid_first.x,
-                    y=grid_first.y,
-                    z=0 * u.mm,
-                )
-                result.outputs.position = grid_first.replace(
-                    z=surface_first.sag(grid_first)
-                )
-                result.outputs.direction = na.Cartesian3dVectorArray(0, 0, 1)
-                component_variable = "direction"
-
-                def zfunc(xy: na.AbstractCartesian2dVectorArray):
-                    return np.sqrt(1 - np.square(xy.length))
-
-            elif na.unit(grid_first).is_equivalent(u.dimensionless_unscaled):
-                result.outputs.direction = na.Cartesian3dVectorArray(
-                    x=grid_first.x,
-                    y=grid_first.y,
-                    z=np.sqrt(1 - np.square(grid_first.length)),
-                )
-                result.outputs.position = na.Cartesian3dVectorArray() * u.mm
-                component_variable = "position"
-
-                def zfunc(xy: na.AbstractCartesian2dVectorArray):
-                    position = na.Cartesian3dVectorArray(
-                        x=xy.x,
-                        y=xy.y,
-                        z=0 * na.unit_normalized(xy.x),
-                    )
-                    return surface_first.sag(position)
-
-            else:  # pragma: nocover
-                raise ValueError(f"unrecognized input grid unit, {na.unit(grid_first)}")
-
-            # Seed the free ray component by aiming each ray at its own
-            # target point on the last stop surface when no surface with
-            # optical power lies between the two stops (the seed is then
-            # nearly exact), and otherwise at the center of the first powered
-            # surface, so that the root-finding starts inside its basin of
-            # convergence even for surfaces far from the axis of the first
-            # stop (e.g. an off-axis fold or feed mirror).
-            anchor = self._anchor_surface(subsystem)
-            if anchor is surface_last and na.unit(grid_last).is_equivalent(u.mm):
-                aim = na.Cartesian3dVectorArray(
-                    x=grid_last.x,
-                    y=grid_last.y,
-                    z=0 * na.unit_normalized(grid_last.x),
-                )
-                aim.z = surface_last.sag(aim)
-                if surface_last.transformation is not None:
-                    aim = surface_last.transformation(aim)
-            else:
-                aim = na.Cartesian3dVectorArray() * u.mm
-                if anchor.transformation is not None:
-                    aim = anchor.transformation(aim)
-            if surface_first.transformation is not None:
-                aim = surface_first.transformation.inverse(aim)
-
-            if component_variable == "direction":
-                d = aim - result.outputs.position
-                d = d / d.length
-                # the sign of the seed direction is irrelevant to the
-                # root-finding problem (surface intercepts may have negative
-                # distance), but the z-component must be positive to be
-                # consistent with `zfunc`
-                flip = np.sign(d.z)
-                where = d.z != 0
-                result.outputs.direction = na.Cartesian3dVectorArray(
-                    x=np.where(where, flip * d.x, 0),
-                    y=np.where(where, flip * d.y, 0),
-                    z=np.where(where, flip * d.z, 1),
-                )
-            else:
-                d = result.outputs.direction
-                t = aim.z / d.z
-                position_seed = na.Cartesian3dVectorArray(
-                    x=aim.x - d.x * t,
-                    y=aim.y - d.y * t,
-                    z=0 * u.mm,
-                )
-                position_seed.z = surface_first.sag(position_seed)
-                result.outputs.position = position_seed
-
-            if surface_first.transformation is not None:
-                result.outputs = surface_first.transformation(result.outputs)
-
-            if na.unit(grid_last).is_equivalent(u.mm):
-                component_target = "position"
-            elif na.unit(grid_last).is_equivalent(u.dimensionless_unscaled):
-                component_target = "direction"
-            else:  # pragma: nocover
-                raise ValueError(f"unrecognized output grid unit, {na.unit(grid_last)}")
-
-            # The residual of the root-finding problem has the same units as
-            # the target grid, so the convergence tolerance must scale with
-            # the size of the target aperture to be achievable in floating
-            # point for systems of any physical scale.
-            scale = np.maximum(
-                grid_last.x.ptp(),
-                grid_last.y.ptp(),
-            )
-            max_abs_error = 1e-9 * np.maximum(
-                scale,
-                1 * na.unit_normalized(scale),
-            )
-
-            variables = getattr(result.outputs, component_variable)
-
-            function = functools.partial(
-                self._ray_error,
-                rays=result.outputs,
+            result.outputs = self._solve_rays(
                 subsystem=subsystem,
+                grid_first=grid_first,
                 grid_last=grid_last,
-                component_variable=component_variable,
-                component_target=component_target,
-                zfunc=zfunc,
+                wavelength=wavelength_input,
             )
-
-            # The default perturbation used by `na.jacobian` is an absolute
-            # 1e-10 in the units of the variable, which is below the
-            # floating-point noise floor of the raytrace for variables
-            # measured in physical units, yielding a Jacobian made of noise.
-            # Use a perturbation proportional to the scale of the problem
-            # instead.
-            if component_variable == "direction":
-                dx = 1e-6
-            else:
-                dx = 1e-6 * np.maximum(
-                    scale,
-                    1 * na.unit_normalized(scale),
-                )
-
-            def jacobian(x, _function=function, _dx=dx):
-                return na.jacobian(function=_function, x=x, dx=_dx)
-
-            try:
-                root = na.optimize.root_newton(
-                    function=function,
-                    guess=na.Cartesian2dVectorArray(
-                        x=variables.x,
-                        y=variables.y,
-                    ),
-                    jacobian=jacobian,
-                    max_abs_error=max_abs_error,
-                )
-            except ValueError as e:  # pragma: nocover
-                raise ValueError(
-                    f"Could not solve for the rays connecting the stop "
-                    f"surfaces {surface_first.name!r} and "
-                    f"{surface_last.name!r}. "
-                    f"If the field stop is only partially reachable at a "
-                    f"single wavelength (e.g. a spectrograph sensor), "
-                    f"consider marking the object surface, with an angular "
-                    f"(dimensionless, sine of the half-angle) aperture, as "
-                    f"the field stop instead."
-                ) from e
-
-            variables.x = root.x
-            variables.y = root.y
-            variables.z = zfunc(root)
 
         return result
 
@@ -843,6 +897,211 @@ class AbstractSequentialSystem(
             y=na.linspace(-1, 1, axis="_pupil_y", num=12),
         )
 
+    def _calc_rayfunction_pupil(
+        self,
+        wavelength: na.ScalarLike,
+        field: na.AbstractCartesian2dVectorArray,
+        rayfunction_stops: None | optika.rays.RayFunctionArray = None,
+        samples_pupil_stop: int = 21,
+    ) -> optika.rays.RayFunctionArray:
+        """
+        Trace the rays from each of the given field points which graze the
+        edge of the pupil stop, to find the entrance pupil of every field
+        point.
+
+        The field is held fixed at each point and only the edge of the pupil
+        stop is swept, so unlike :attr:`rayfunction_stops`, which sweeps the
+        edges of both stops at once, the entrance pupil here is resolved as a
+        function of field instead of being collapsed into one bounding box
+        shared by every field point.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelength of the rays.
+        field
+            The field points at which to find the entrance pupil, in angle if
+            the object is at infinity and in position if it is not.
+        rayfunction_stops
+            The result of :meth:`_calc_rayfunction_stops` on `wavelength`.
+            If given, and the object is at infinity, the solve is seeded at
+            the center of the entrance pupil it locates.
+        samples_pupil_stop
+            The number of points along the edge of the pupil stop.
+        """
+        surfaces = self.surfaces_all
+        subsystem = surfaces[: self.index_pupil_stop + 1]
+
+        pupil_stop = subsystem[~0]
+        grid_last = np.moveaxis(
+            a=pupil_stop.aperture.wire(num=samples_pupil_stop),
+            source="wire",
+            destination=self.axis_pupil_stop,
+        )
+        grid_last = na.Cartesian2dVectorArray(grid_last.x, grid_last.y)
+
+        # The field fixes one component of the ray leaving the object, and
+        # the solver finds the other: the position for an object at infinity,
+        # whose field is a direction, and the direction otherwise.
+        if self.object_is_at_infinity:
+            direction = optika.direction(field)
+            grid_first = na.Cartesian2dVectorArray(direction.x, direction.y)
+        else:
+            grid_first = na.Cartesian2dVectorArray(field.x, field.y)
+
+        # Seed the solve at the center of the entrance pupil of the whole
+        # system, which the stops locate, rather than at the first powered
+        # surface: for an off-axis system the pupil can sit far from the axis
+        # of that surface, outside the basin of convergence of a seed aimed
+        # there.  The pupil of any one field point walks only a fraction of
+        # the whole pupil away from its center, so every field point starts
+        # close to its own solution.
+        aim = None
+        if rayfunction_stops is not None and self.object_is_at_infinity:
+            aim = rayfunction_stops.outputs.position.mean(self.axis_stops)
+
+        rays = self._solve_rays(
+            subsystem=subsystem,
+            grid_first=grid_first,
+            grid_last=grid_last,
+            wavelength=wavelength,
+            aim=aim,
+        )
+
+        # The solved component carries the pupil-stop axis and the fixed one
+        # only the field axes, so broadcast them against each other to keep
+        # reductions over either well-defined downstream.
+        shape = na.shape_broadcasted(rays.position, rays.direction)
+        rays.position = rays.position.broadcast_to(shape)
+        rays.direction = rays.direction.broadcast_to(shape)
+
+        return optika.rays.RayFunctionArray(
+            inputs=optika.vectors.ObjectVectorArray(
+                wavelength=wavelength,
+                field=field,
+                pupil=grid_last,
+            ),
+            outputs=rays,
+        )
+
+    def _calc_pupil_fit(
+        self,
+        wavelength: na.ScalarLike,
+        rayfunction_stops: optika.rays.RayFunctionArray,
+    ) -> tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
+        """
+        Fit the lower-left and upper-right corners of the entrance pupil as
+        polynomials in field.
+
+        The entrance pupil of an off-axis system walks across the field, so
+        the bounding box shared by every field point can be many times larger
+        than the pupil of any one of them.  The rays which graze both stops
+        already resolve the pupil at every point along the edge of the field,
+        so those make up the bulk of the samples and cost nothing more.  One
+        more sample, at the center of the field, is traced explicitly: the
+        edge of a round field lies on a single conic, along which a quadratic
+        cannot tell a constant from a radial term, so a sample away from the
+        edge is what pins down the size of the pupil in the interior.
+
+        The fit depends on nothing but the wavelengths, so it is made once and
+        evaluated at any field grid for free, which keeps the solves out of
+        the callers that denormalize several grids at once.
+
+        Parameters
+        ----------
+        wavelength
+            The wavelengths at which to calibrate the pupil.
+        rayfunction_stops
+            The result of :meth:`_calc_rayfunction_stops` on `wavelength`.
+
+        Returns
+        -------
+            The fits of the lower-left and upper-right corners of the pupil.
+        """
+        rays = rayfunction_stops.outputs
+        if self.object_is_at_infinity:
+            field = optika.angles(rays.direction)
+            pupil = rays.position.xy
+        else:
+            field = rays.position.xy
+            pupil = optika.angles(rays.direction)
+
+        # The stop grids are swept along the two stop axes in the order the
+        # stops appear in the system, not by which stop each belongs to, so
+        # find the axis along the edge of the pupil stop from the input pupil
+        # grid, which is labeled by stop.
+        axis_stops = self.axis_stops
+        axis_wire = tuple(
+            ax for ax in axis_stops if ax in na.shape(rayfunction_stops.inputs.pupil)
+        )
+        (axis_edge,) = tuple(ax for ax in axis_stops if ax not in axis_wire)
+
+        # the field is constant along the edge of the pupil stop
+        field_edge = field.mean(axis_wire)
+        pupil_min_edge = pupil.min(axis_wire)
+        pupil_max_edge = pupil.max(axis_wire)
+
+        # one more sample at the center of the field, traced explicitly
+        field_center = field_edge.mean(axis_edge)
+        rays_center = self._calc_rayfunction_pupil(
+            wavelength=wavelength,
+            field=field_center,
+            rayfunction_stops=rayfunction_stops,
+        ).outputs
+        if self.object_is_at_infinity:
+            pupil_center = rays_center.position.xy
+        else:
+            pupil_center = optika.angles(rays_center.direction)
+        axis_pupil = self.axis_pupil_stop
+        pupil_min_center = pupil_center.min(axis_pupil)
+        pupil_max_center = pupil_center.max(axis_pupil)
+
+        # The samples along the edge come from rays which pass both stops,
+        # but the one at the center traces only the pupil stop, so in a
+        # system limited by its field stop instead the two disagree, and a
+        # polynomial forced through them overshoots between.  No field point
+        # can accept more than the union of every ray which passes both
+        # stops, so hold the center sample to that bound before fitting, the
+        # same bound the fit is held to wherever it is evaluated.
+        pupil_min_center = np.maximum(pupil_min_center, pupil.min(axis_stops))
+        pupil_max_center = np.minimum(pupil_max_center, pupil.max(axis_stops))
+
+        # join the samples along the edge of the field with the one at its
+        # center, along the axis of the edge
+        def join(
+            edge: na.AbstractCartesian2dVectorArray,
+            center: na.AbstractCartesian2dVectorArray,
+        ) -> na.AbstractCartesian2dVectorArray:
+            shape = na.broadcast_shapes(na.shape(center), {axis_edge: 1})
+            return np.concatenate([edge, center.broadcast_to(shape)], axis=axis_edge)
+
+        field = join(field_edge, field_center)
+        pupil_min = join(pupil_min_edge, pupil_min_center)
+        pupil_max = join(pupil_max_edge, pupil_max_center)
+
+        # The wavelength is carried along as a plain broadcast axis, since the
+        # fit is only ever evaluated at the wavelengths it was made at, so the
+        # polynomial is in the field alone.
+        #
+        # The least-squares solve for the coefficients is linear in the
+        # outputs, so the uncertainty of the pupil samples passes through it
+        # exactly, but the inputs enter it through a matrix inverse which an
+        # uncertain array cannot take.  Fit against the nominal inputs, which
+        # drops only the uncertainty in where the samples sit, not in the
+        # pupil found there.
+        inputs = na.nominal(optika.vectors.SceneVectorArray(wavelength, field))
+
+        def fit(outputs: na.AbstractCartesian2dVectorArray):
+            return na.PolynomialFitFunctionArray.from_degree(
+                inputs=inputs,
+                outputs=outputs,
+                degree=2,
+                components=("field.x", "field.y"),
+                axis_polynomial=axis_edge,
+            )
+
+        return fit(pupil_min), fit(pupil_max)
+
     def _denormalize_grid(
         self,
         grid: optika.vectors.ObjectVectorArray,
@@ -853,9 +1112,17 @@ class AbstractSequentialSystem(
         if (not normalized_field) and (not normalized_pupil):
             return grid
 
+        rayfunction_stops = self._calc_rayfunction_stops(grid.wavelength)
+
+        # the pupil is only calibrated when it needs denormalizing
+        pupil_fit = None
+        if normalized_pupil:
+            pupil_fit = self._calc_pupil_fit(grid.wavelength, rayfunction_stops)
+
         return self._denormalize_grid_from_rays(
             grid=grid,
-            rayfunction_stops=self._calc_rayfunction_stops(grid.wavelength),
+            rayfunction_stops=rayfunction_stops,
+            pupil_fit=pupil_fit,
             normalized_field=normalized_field,
             normalized_pupil=normalized_pupil,
         )
@@ -864,12 +1131,15 @@ class AbstractSequentialSystem(
         self,
         grid: optika.vectors.ObjectVectorArray,
         rayfunction_stops: optika.rays.RayFunctionArray,
+        pupil_fit: (
+            None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]
+        ) = None,
         normalized_field: bool = True,
         normalized_pupil: bool = True,
     ) -> optika.vectors.ObjectVectorArray:
         """
-        Map a normalized grid onto the field and pupil that the given stop
-        rayfunction describes.
+        Map a normalized grid onto the field that the given stop rayfunction
+        describes, and onto the entrance pupil of each of its field points.
 
         Parameters
         ----------
@@ -878,6 +1148,11 @@ class AbstractSequentialSystem(
         rayfunction_stops
             The result of :meth:`_calc_rayfunction_stops` on the wavelengths
             of `grid`.
+        pupil_fit
+            The result of :meth:`_calc_pupil_fit` on the wavelengths of
+            `grid`, the fits of the corners of the entrance pupil as a
+            function of field.
+            Required if `normalized_pupil` is :obj:`True`.
         normalized_field
             A boolean flag indicating whether the field of `grid` is given in
             normalized or physical units.
@@ -890,8 +1165,7 @@ class AbstractSequentialSystem(
 
         result = grid.copy_shallow()
 
-        object_is_at_infinity = self.object_is_at_infinity
-        if object_is_at_infinity:
+        if self.object_is_at_infinity:
             field = optika.angles(rayfunction_stops.outputs.direction)
             pupil = rayfunction_stops.outputs.position.xy
         else:
@@ -904,9 +1178,44 @@ class AbstractSequentialSystem(
             result.field = ptp_field * (result.field + 1) / 2 + min_field
 
         if normalized_pupil:
-            min_pupil = pupil.min(axis=(axis_field, axis_pupil))
-            ptp_pupil = pupil.ptp(axis=(axis_field, axis_pupil))
-            result.pupil = ptp_pupil * (result.pupil + 1) / 2 + min_pupil
+            # The pupil is the one belonging to each field point, evaluated
+            # from the fit, rather than the single bounding box shared by
+            # every field point, which for an off-axis system can be many
+            # times larger than the pupil of any one of them.
+            fit_min, fit_max = pupil_fit
+            x = optika.vectors.SceneVectorArray(result.wavelength, result.field)
+            fit_min = fit_min(x).outputs
+            fit_max = fit_max(x).outputs
+
+            # No field point can accept more than the union of every ray
+            # which passes both stops, so bound the pupil of each field point
+            # to that.  A system limited by its field stop rather than its
+            # pupil stop has no smooth pupil for the fit to follow, and its
+            # box then collapses or turns inside out under the bound; fall
+            # back to the whole pupil wherever that happens, so that every
+            # box sampled is a real part of the pupil and never worse than
+            # the box shared by every field point.
+            axis_both = (axis_field, axis_pupil)
+            global_min = pupil.min(axis=axis_both)
+            global_max = pupil.max(axis=axis_both)
+
+            def bound(
+                lo: na.AbstractScalar,
+                hi: na.AbstractScalar,
+                lo_global: na.AbstractScalar,
+                hi_global: na.AbstractScalar,
+            ) -> tuple[na.AbstractScalar, na.AbstractScalar]:
+                lo = np.maximum(lo, lo_global)
+                hi = np.minimum(hi, hi_global)
+                bad = hi <= lo
+                return np.where(bad, lo_global, lo), np.where(bad, hi_global, hi)
+
+            min_x, max_x = bound(fit_min.x, fit_max.x, global_min.x, global_max.x)
+            min_y, max_y = bound(fit_min.y, fit_max.y, global_min.y, global_max.y)
+            min_pupil = na.Cartesian2dVectorArray(x=min_x, y=min_y)
+            max_pupil = na.Cartesian2dVectorArray(x=max_x, y=max_y)
+
+            result.pupil = (max_pupil - min_pupil) * (result.pupil + 1) / 2 + min_pupil
 
         return result
 
@@ -1733,6 +2042,18 @@ class AbstractSequentialSystem(
 
         area = np.abs(pupil.volume_cell(axis=axis_pupil))
 
+        # The entrance pupil belongs to each field point, so the pupil grid,
+        # and the area of its cells, carry the field axes at the resolution
+        # of the field vertices.  Bring them to the centers of the field
+        # cells here, to line up with the field samples drawn below.  The
+        # pupil walks smoothly across a single cell of the field, so its
+        # value at the center of the cell stands in for its value at the
+        # point drawn inside it.
+        axis_field_pupil = tuple(ax for ax in axis_field if ax in na.shape(pupil))
+        if axis_field_pupil:
+            area = area.cell_centers(axis=axis_field_pupil)
+            pupil = pupil.cell_centers(axis=axis_field_pupil)
+
         # Both grids are sampled once per cell, at a point drawn uniformly
         # inside it.  Stratifying this way rather than taking the cell centers
         # keeps the quadrature from aliasing against the edge of the field
@@ -1888,10 +2209,14 @@ class AbstractSequentialSystem(
         pupil_centers = pupil.cell_centers(axis=axis_pupil)
 
         # Each of the three fits below denormalizes its own grid, and the
-        # expensive part of that is solving for the stops, which depends on
-        # nothing but the wavelengths.  Solve once here and hand each of them
-        # a grid which is already physical.
+        # expensive part of that is solving for the stops and calibrating the
+        # entrance pupil, both of which depend on nothing but the wavelengths.
+        # Solve once here and hand each of them a grid which is already
+        # physical.
         stops = self._calc_rayfunction_stops(wavelength)
+        pupil_fit = None
+        if normalized_pupil:
+            pupil_fit = self._calc_pupil_fit(wavelength, stops)
 
         def denormalize(
             field: na.AbstractCartesian2dVectorArray,
@@ -1904,6 +2229,7 @@ class AbstractSequentialSystem(
                     pupil=pupil,
                 ),
                 rayfunction_stops=stops,
+                pupil_fit=pupil_fit,
                 normalized_field=normalized_field,
                 normalized_pupil=normalized_pupil,
             )

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -398,6 +398,16 @@ class AbstractSequentialSystem(
         rays_component_variable.y = a.y
         rays_component_variable.z = zfunc(a)
 
+        # The trial ray is fixed in the local coordinates of the launch
+        # surface, so carry it into the global coordinates the rest of the
+        # subsystem is in before tracing it.  Otherwise a launch surface
+        # translated along the axis launches every trial from the wrong depth,
+        # and a ray with any angle to the axis misses the surfaces it should
+        # strike by the drift of the ray across that depth.
+        transformation_first = subsystem[0].transformation
+        if transformation_first is not None:
+            rays = transformation_first(rays)
+
         # only the geometry of these rays is used, and the objective is
         # evaluated once per iteration of the solver, so the efficiency of
         # each surface would be by far the most expensive part of finding
@@ -549,8 +559,10 @@ class AbstractSequentialSystem(
             position_seed.z = surface_first.sag(position_seed)
             rays.position = position_seed
 
-        if surface_first.transformation is not None:
-            rays = surface_first.transformation(rays)
+        # The rays stay in the local coordinates of the launch surface for the
+        # solve, since that is where the free component is fixed; `_ray_error`
+        # carries each trial into global coordinates, and the result is
+        # carried there once at the end.
 
         if na.unit(grid_last).is_equivalent(u.mm):
             component_target = "position"
@@ -626,6 +638,10 @@ class AbstractSequentialSystem(
         variables.x = root.x
         variables.y = root.y
         variables.z = zfunc(root)
+
+        # the rays were solved in the local coordinates of the launch surface
+        if surface_first.transformation is not None:
+            rays = surface_first.transformation(rays)
 
         return rays
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -16,9 +16,26 @@ from . import AbstractSystem
 from . import LinearSystem
 
 __all__ = [
+    "StopSolveError",
     "AbstractSequentialSystem",
     "SequentialSystem",
 ]
+
+
+class StopSolveError(ValueError):
+    """
+    The two-point solve which connects a pair of surfaces did not converge.
+
+    Raised by the search for the rays which graze the edge of both stops, and
+    by the search for the entrance pupil of a single field point, both of
+    which are Newton solves that can be started outside their basin of
+    convergence or asked for a ray which does not exist.
+
+    It derives from :class:`ValueError`, which is what this solve raised
+    before it was named, so code which already catches that keeps working.
+    Catching this instead distinguishes a solve which did not converge from a
+    system which was built wrong, which the same call can also report.
+    """
 
 
 @dataclasses.dataclass(eq=False, repr=False)
@@ -437,6 +454,7 @@ class AbstractSequentialSystem(
         grid_last: na.AbstractCartesian2dVectorArray,
         wavelength: na.ScalarLike,
         aim: None | na.AbstractCartesian3dVectorArray = None,
+        hint: str = "",
     ) -> optika.rays.RayVectorArray:
         """
         Solve for the rays launched from `grid_first` on the first surface of
@@ -465,11 +483,20 @@ class AbstractSequentialSystem(
             If :obj:`None` (the default), each ray is aimed at its own target
             point when no surface with optical power lies between the two
             ends, and otherwise at the center of the first powered surface.
+        hint
+            Advice to append to the error raised if the solve does not
+            converge. Two callers share this solve and what a user can do
+            about a failure differs between them, so each supplies its own.
 
         Returns
         -------
             The solved launch rays, in the global coordinates of the first
             surface.
+
+        Raises
+        ------
+        StopSolveError
+            If the solve does not converge.
         """
         surface_first = subsystem[0]
         surface_last = subsystem[~0]
@@ -624,15 +651,18 @@ class AbstractSequentialSystem(
                 max_abs_error=max_abs_error,
             )
         except ValueError as e:  # pragma: nocover
-            raise ValueError(
+
+            def described(surface: optika.surfaces.AbstractSurface) -> str:
+                # a surface need not be named, and 'None and None' names
+                # nothing at all
+                if surface.name is not None:
+                    return repr(surface.name)
+                return f"an unnamed {type(surface).__name__}"
+
+            raise StopSolveError(
                 f"Could not solve for the rays connecting the "
-                f"surfaces {surface_first.name!r} and "
-                f"{surface_last.name!r}. "
-                f"If the field stop is only partially reachable at a "
-                f"single wavelength (e.g. a spectrograph sensor), "
-                f"consider marking the object surface, with an angular "
-                f"(dimensionless, sine of the half-angle) aperture, as "
-                f"the field stop instead."
+                f"surfaces {described(surface_first)} and "
+                f"{described(surface_last)}. " + hint
             ) from e
 
         variables.x = root.x
@@ -717,6 +747,13 @@ class AbstractSequentialSystem(
                 grid_first=grid_first,
                 grid_last=grid_last,
                 wavelength=wavelength_input,
+                hint=(
+                    "If the field stop is only partially reachable at a "
+                    "single wavelength (e.g. a spectrograph sensor), "
+                    "consider marking the object surface, with an angular "
+                    "(dimensionless, sine of the half-angle) aperture, as "
+                    "the field stop instead."
+                ),
             )
 
         return result
@@ -807,6 +844,22 @@ class AbstractSequentialSystem(
         A rayfunction defined on the input surface of the optical system,
         which is designed to exactly strike the borders of both the field
         stop and the pupil stop.
+
+        This property is cached to increase performance, and so are the
+        results which depend on it.  :meth:`raytrace` and :meth:`image`
+        denormalize a grid against these rays and against :attr:`pupil_fit`,
+        so both read the caches rather than solving afresh.
+
+        Nothing detects a system which is changed after they are filled.  A
+        new system is the reliable way to change one, since these are the
+        caches a change invalidates:
+
+        * :attr:`rayfunction_stops`
+        * :attr:`pupil_fit`
+        * :attr:`rayfunction_default`
+
+        Clear them with ``del system.rayfunction_stops`` and so on, in that
+        order, if a system must be changed in place.
         """
         return self._calc_rayfunction_stops(self.grid_input.wavelength)
 
@@ -865,9 +918,9 @@ class AbstractSequentialSystem(
         :obj:`None` if the pupil could not be calibrated per field point, in
         which case the box shared by every field point is used instead.
 
-        This property is cached to increase performance.
-        If :attr:`grid_input` is updated, the cache must be cleared with
-        ``del system.pupil_fit`` before calling this property.
+        This property is cached to increase performance.  See
+        :attr:`rayfunction_stops` for what invalidates it and for the other
+        caches which go with it.
         """
         wavelength = self.grid_input.wavelength
         return self._calc_pupil_fit(wavelength, self._rayfunction_stops(wavelength))
@@ -896,8 +949,14 @@ class AbstractSequentialSystem(
         # The cache is only good for the stop rays it was built from.  A caller
         # which solved its own stops, at a different number of wire samples
         # say, must be given a fit which matches them.
+        #
+        # Read the cache rather than `rayfunction_stops` itself: asking the
+        # property whether the given rays are the cached ones would solve for
+        # them when they are not cached, which is the most expensive thing
+        # this class does, only to find they are not the same and throw the
+        # answer away.
         if self._wavelength_is_default(wavelength):
-            if rayfunction_stops is self.rayfunction_stops:
+            if rayfunction_stops is self.__dict__.get("rayfunction_stops"):
                 return self.pupil_fit
 
         return self._calc_pupil_fit(wavelength, rayfunction_stops)
@@ -1084,6 +1143,11 @@ class AbstractSequentialSystem(
             grid_last=grid_last,
             wavelength=wavelength,
             aim=aim,
+            hint=(
+                "This is the entrance pupil of one field point, which the "
+                "system falls back to a pupil shared by every field point "
+                "without."
+            ),
         )
 
         # `_calc_pupil_fit` fits these against samples taken from the stop
@@ -1184,7 +1248,7 @@ class AbstractSequentialSystem(
                 field=field_center,
                 rayfunction_stops=rayfunction_stops,
             ).outputs
-        except ValueError:
+        except StopSolveError:
             # The pupil of the center of the field could not be found, so
             # there is nothing to fit.  The caller then falls back to the box
             # shared by every field point, which is never worse than before
@@ -1252,7 +1316,11 @@ class AbstractSequentialSystem(
 
         try:
             return fit(pupil_min), fit(pupil_max)
-        except ValueError:
+        except np.linalg.LinAlgError:
+            # Only a design matrix which cannot be inverted falls back.  A
+            # `ValueError` from anywhere else in the fit is a system built
+            # wrong or a mistake in this method, and silently disabling the
+            # per-field pupil forever would hide it.
             return None
 
     def _denormalize_grid(
@@ -1620,9 +1688,9 @@ class AbstractSequentialSystem(
         Computes the rays in local coordinates at the last surface in the system
         as a function of input wavelength and position using :attr:`grid_input`.
 
-        This property is cached to increase performance.
-        If :attr:`grid_input` is updated, the cache must be cleared with
-        ``del system.rayfunction_default`` before calling this property.
+        This property is cached to increase performance.  See
+        :attr:`rayfunction_stops` for what invalidates it and for the other
+        caches which go with it.
         """
         return self.rayfunction()
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -883,30 +883,6 @@ class AbstractSequentialSystem(
 
         return bool(np.all(wavelength == wavelength_default))
 
-    def _rayfunction_stops(
-        self,
-        wavelength: na.ScalarLike,
-    ) -> optika.rays.RayFunctionArray:
-        """
-        The stop rays at the given wavelength, reusing
-        :attr:`rayfunction_stops` when that was solved at the same wavelength.
-
-        Solving for the stop rays is among the most expensive things this class
-        does, and denormalizing a grid needs them every time.  Most callers
-        denormalize against the system's own input wavelengths, which
-        :attr:`rayfunction_stops` has already solved for, so going through the
-        cache saves the whole solve.
-
-        Parameters
-        ----------
-        wavelength
-            The wavelength to solve the stop rays at.
-        """
-        if self._wavelength_is_default(wavelength):
-            return self.rayfunction_stops
-
-        return self._calc_rayfunction_stops(wavelength)
-
     @functools.cached_property
     def pupil_fit(
         self,
@@ -922,44 +898,54 @@ class AbstractSequentialSystem(
         :attr:`rayfunction_stops` for what invalidates it and for the other
         caches which go with it.
         """
-        wavelength = self.grid_input.wavelength
-        return self._calc_pupil_fit(wavelength, self._rayfunction_stops(wavelength))
+        return self._calc_pupil_fit(
+            self.grid_input.wavelength,
+            self.rayfunction_stops,
+        )
 
-    def _pupil_fit(
+    def _stops_and_pupil_fit(
         self,
         wavelength: na.ScalarLike,
-        rayfunction_stops: optika.rays.RayFunctionArray,
-    ) -> None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
+        normalized_pupil: bool = True,
+    ) -> tuple[
+        optika.rays.RayFunctionArray,
+        None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray],
+    ]:
         """
-        The entrance pupil fit at the given wavelength, reusing
-        :attr:`pupil_fit` when that was solved at the same wavelength.
+        The stop rays at a wavelength, and the entrance pupil fit from them.
 
-        Calibrating the pupil traces the field edges and one field center for
-        every wavelength, which costs more than the rest of denormalizing a
-        grid put together.  It depends on nothing but the wavelengths, so a
-        caller working at the system's own input wavelengths pays for it once.
+        Everything denormalizing a grid needs, and the expensive part of doing
+        it: solving for the stop rays is the single costliest thing this class
+        does, and calibrating the pupil costs more than the rest of the
+        denormalization put together.  Both depend on nothing but the
+        wavelength, so at the wavelengths of :attr:`grid_input` both come from
+        the cache and a caller pays for neither, however many grids it
+        denormalizes.
+
+        They are returned together because a fit only describes the rays it
+        was built from, so pairing them here is what keeps a caller from
+        holding one of each.
 
         Parameters
         ----------
         wavelength
-            The wavelength to calibrate the pupil at.
-        rayfunction_stops
-            The stop rays at that wavelength.
-        """
-        # The cache is only good for the stop rays it was built from.  A caller
-        # which solved its own stops, at a different number of wire samples
-        # say, must be given a fit which matches them.
-        #
-        # Read the cache rather than `rayfunction_stops` itself: asking the
-        # property whether the given rays are the cached ones would solve for
-        # them when they are not cached, which is the most expensive thing
-        # this class does, only to find they are not the same and throw the
-        # answer away.
-        if self._wavelength_is_default(wavelength):
-            if rayfunction_stops is self.__dict__.get("rayfunction_stops"):
-                return self.pupil_fit
+            The wavelength to solve at.
+        normalized_pupil
+            Whether the pupil fit is wanted at all.  Denormalizing a grid
+            whose pupil is already physical does not need it, and calibrating
+            it anyway would be the most expensive part of that call.
 
-        return self._calc_pupil_fit(wavelength, rayfunction_stops)
+        Returns
+        -------
+            The stop rays, and the pupil fit or :obj:`None`.
+        """
+        if self._wavelength_is_default(wavelength):
+            stops = self.rayfunction_stops
+            return stops, self.pupil_fit if normalized_pupil else None
+
+        stops = self._calc_rayfunction_stops(wavelength)
+        fit = self._calc_pupil_fit(wavelength, stops) if normalized_pupil else None
+        return stops, fit
 
     @property
     def axis_stops(self) -> tuple[str, str]:
@@ -971,6 +957,37 @@ class AbstractSequentialSystem(
         outline into a measurement of the system.
         """
         return (self.axis_field_stop, self.axis_pupil_stop)
+
+    def _field_and_pupil(
+        self,
+        rays: optika.rays.AbstractRayVectorArray,
+    ) -> tuple[na.AbstractCartesian2dVectorArray, na.AbstractCartesian2dVectorArray]:
+        """
+        Read the field and pupil coordinates a set of rays represents.
+
+        Which of a ray's position and direction is its field and which is its
+        pupil depends on where the object is: an object at infinity has no
+        position to speak of, so its field is the direction the ray arrives
+        from and its pupil is where on the object surface it crosses, and an
+        object at a finite distance is the other way round.
+
+        Parameters
+        ----------
+        rays
+            Rays in the frame of the object surface, as
+            :meth:`_calc_rayfunction_stops` and :meth:`_calc_rayfunction_pupil`
+            return them.
+
+        Returns
+        -------
+            The field and the pupil coordinates, in that order.
+        """
+        position = rays.position.xy
+        direction = optika.angles(rays.direction)
+        if self.object_is_at_infinity:
+            return direction, position
+        else:
+            return position, direction
 
     @property
     def field_boundary(self) -> na.AbstractCartesian2dVectorArray:
@@ -991,11 +1008,8 @@ class AbstractSequentialSystem(
         the instrument at hand takes to be its field of view;
         :attr:`field_min` and :attr:`field_max` are two such reductions.
         """
-        rays = self.rayfunction_stops.outputs
-        if self.object_is_at_infinity:
-            return optika.angles(rays.direction)
-        else:
-            return rays.position.xy
+        field, _ = self._field_and_pupil(self.rayfunction_stops.outputs)
+        return field
 
     @property
     def pupil_boundary(self) -> na.AbstractCartesian2dVectorArray:
@@ -1005,11 +1019,8 @@ class AbstractSequentialSystem(
         The counterpart of :attr:`field_boundary`, in position if the object is
         at infinity and in angle if it is not.
         """
-        rays = self.rayfunction_stops.outputs
-        if self.object_is_at_infinity:
-            return rays.position.xy
-        else:
-            return optika.angles(rays.direction)
+        _, pupil = self._field_and_pupil(self.rayfunction_stops.outputs)
+        return pupil
 
     @property
     def field_min(self) -> na.AbstractCartesian2dVectorArray:
@@ -1212,13 +1223,7 @@ class AbstractSequentialSystem(
             be found, in which case the box shared by every field point
             should be used instead.
         """
-        rays = rayfunction_stops.outputs
-        if self.object_is_at_infinity:
-            field = optika.angles(rays.direction)
-            pupil = rays.position.xy
-        else:
-            field = rays.position.xy
-            pupil = optika.angles(rays.direction)
+        field, pupil = self._field_and_pupil(rayfunction_stops.outputs)
 
         # The stop grids are swept along the two stop axes in the order the
         # stops appear in the system, not by which stop each belongs to, so
@@ -1255,10 +1260,7 @@ class AbstractSequentialSystem(
             # this fit existed, rather than failing a raytrace which the
             # shared box would have carried out.
             return None
-        if self.object_is_at_infinity:
-            pupil_center = rays_center.position.xy
-        else:
-            pupil_center = optika.angles(rays_center.direction)
+        _, pupil_center = self._field_and_pupil(rays_center)
         axis_pupil = self.axis_pupil_stop
         pupil_min_center = pupil_center.min(axis_pupil)
         pupil_max_center = pupil_center.max(axis_pupil)
@@ -1333,12 +1335,10 @@ class AbstractSequentialSystem(
         if (not normalized_field) and (not normalized_pupil):
             return grid
 
-        rayfunction_stops = self._rayfunction_stops(grid.wavelength)
-
-        # the pupil is only calibrated when it needs denormalizing
-        pupil_fit = None
-        if normalized_pupil:
-            pupil_fit = self._pupil_fit(grid.wavelength, rayfunction_stops)
+        rayfunction_stops, pupil_fit = self._stops_and_pupil_fit(
+            grid.wavelength,
+            normalized_pupil,
+        )
 
         return self._denormalize_grid_from_rays(
             grid=grid,
@@ -1387,12 +1387,7 @@ class AbstractSequentialSystem(
 
         result = grid.copy_shallow()
 
-        if self.object_is_at_infinity:
-            field = optika.angles(rayfunction_stops.outputs.direction)
-            pupil = rayfunction_stops.outputs.position.xy
-        else:
-            field = rayfunction_stops.outputs.position.xy
-            pupil = optika.angles(rayfunction_stops.outputs.direction)
+        field, pupil = self._field_and_pupil(rayfunction_stops.outputs)
 
         if normalized_field:
             min_field = field.min(axis=(axis_field, axis_pupil))
@@ -2485,10 +2480,7 @@ class AbstractSequentialSystem(
         # entrance pupil, both of which depend on nothing but the wavelengths.
         # Solve once here and hand each of them a grid which is already
         # physical.
-        stops = self._rayfunction_stops(wavelength)
-        pupil_fit = None
-        if normalized_pupil:
-            pupil_fit = self._pupil_fit(wavelength, stops)
+        stops, pupil_fit = self._stops_and_pupil_fit(wavelength, normalized_pupil)
 
         def denormalize(
             field: na.AbstractCartesian2dVectorArray,

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -761,10 +761,15 @@ class AbstractSequentialSystem(
         obj = subsystem[~0]
         rays = result.outputs
         if obj.transformation is not None:
+            # express the stop rays in the local coordinates of the object
+            # surface, since that is the frame in which the field and pupil
+            # coordinates of the input grid are interpreted by
+            # `_calc_rayfunction_input`
             rays = obj.transformation.inverse(rays)
 
         where = rays.direction @ obj.sag.normal(rays.position) > 0
-        result.outputs.direction[where] = -result.outputs.direction[where]
+        rays.direction[where] = -rays.direction[where]
+        result.outputs = rays
 
         # If the first stop is the object surface, the solved variable is the
         # position and the direction retains only the field-stop axis, so
@@ -1067,6 +1072,11 @@ class AbstractSequentialSystem(
         aim = None
         if rayfunction_stops is not None and self.object_is_at_infinity:
             aim = rayfunction_stops.outputs.position.mean(self.axis_stops)
+            # the stop rays are expressed in the object's local coordinates,
+            # while `_solve_rays` aims in global ones
+            obj = subsystem[0]
+            if obj.transformation is not None:
+                aim = obj.transformation(aim)
 
         rays = self._solve_rays(
             subsystem=subsystem,
@@ -1087,6 +1097,15 @@ class AbstractSequentialSystem(
             rays=rays,
             efficiency=False,
         )
+
+        # `_calc_pupil_fit` fits these against samples taken from the stop
+        # rays, which `_calc_rayfunction_stops` expresses in the object's own
+        # coordinates.  Express these the same way, so that the two are
+        # measured in one frame; otherwise a rotated object trains the fit on
+        # a center sample taken at a different field point than the edges.
+        obj = subsystem[0]
+        if obj.transformation is not None:
+            rays = obj.transformation.inverse(rays)
 
         # The solved component carries the pupil-stop axis and the fixed one
         # only the field axes, so broadcast them against each other to keep
@@ -1581,8 +1600,17 @@ class AbstractSequentialSystem(
         rayfunction = raytrace[{axis: ~0}]
         rays = rayfunction.outputs
 
-        if self.sensor.transformation is not None:
-            rays = self.sensor.transformation.inverse(rays)
+        # The sensor sits where `surfaces_all` puts it, which is its own
+        # transformation with `transformation` composed on top, so both are
+        # needed to express these rays in the frame of the sensor. Using only
+        # the sensor's own transformation leaves the rays of a system with a
+        # `transformation` in neither the sensor's frame nor the global one.
+        transformation = na.transformations.compose(
+            self.transformation,
+            self.sensor.transformation,
+        )
+        if transformation is not None:
+            rays = transformation.inverse(rays)
 
         rayfunction.outputs = rays
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -988,7 +988,7 @@ class AbstractSequentialSystem(
         self,
         wavelength: na.ScalarLike,
         rayfunction_stops: optika.rays.RayFunctionArray,
-    ) -> tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
+    ) -> None | tuple[na.PolynomialFitFunctionArray, na.PolynomialFitFunctionArray]:
         """
         Fit the lower-left and upper-right corners of the entrance pupil as
         polynomials in field.
@@ -1016,7 +1016,10 @@ class AbstractSequentialSystem(
 
         Returns
         -------
-            The fits of the lower-left and upper-right corners of the pupil.
+            The fits of the lower-left and upper-right corners of the pupil,
+            or :obj:`None` if the pupil of the center of the field could not
+            be found, in which case the box shared by every field point
+            should be used instead.
         """
         rays = rayfunction_stops.outputs
         if self.object_is_at_infinity:
@@ -1043,11 +1046,19 @@ class AbstractSequentialSystem(
 
         # one more sample at the center of the field, traced explicitly
         field_center = field_edge.mean(axis_edge)
-        rays_center = self._calc_rayfunction_pupil(
-            wavelength=wavelength,
-            field=field_center,
-            rayfunction_stops=rayfunction_stops,
-        ).outputs
+        try:
+            rays_center = self._calc_rayfunction_pupil(
+                wavelength=wavelength,
+                field=field_center,
+                rayfunction_stops=rayfunction_stops,
+            ).outputs
+        except ValueError:
+            # The pupil of the center of the field could not be found, so
+            # there is nothing to fit.  The caller then falls back to the box
+            # shared by every field point, which is never worse than before
+            # this fit existed, rather than failing a raytrace which the
+            # shared box would have carried out.
+            return None
         if self.object_is_at_infinity:
             pupil_center = rays_center.position.xy
         else:
@@ -1152,7 +1163,8 @@ class AbstractSequentialSystem(
             The result of :meth:`_calc_pupil_fit` on the wavelengths of
             `grid`, the fits of the corners of the entrance pupil as a
             function of field.
-            Required if `normalized_pupil` is :obj:`True`.
+            If :obj:`None`, the box shared by every field point is used
+            instead.
         normalized_field
             A boolean flag indicating whether the field of `grid` is given in
             normalized or physical units.
@@ -1178,42 +1190,51 @@ class AbstractSequentialSystem(
             result.field = ptp_field * (result.field + 1) / 2 + min_field
 
         if normalized_pupil:
-            # The pupil is the one belonging to each field point, evaluated
-            # from the fit, rather than the single bounding box shared by
-            # every field point, which for an off-axis system can be many
-            # times larger than the pupil of any one of them.
-            fit_min, fit_max = pupil_fit
-            x = optika.vectors.SceneVectorArray(result.wavelength, result.field)
-            fit_min = fit_min(x).outputs
-            fit_max = fit_max(x).outputs
-
-            # No field point can accept more than the union of every ray
-            # which passes both stops, so bound the pupil of each field point
-            # to that.  A system limited by its field stop rather than its
-            # pupil stop has no smooth pupil for the fit to follow, and its
-            # box then collapses or turns inside out under the bound; fall
-            # back to the whole pupil wherever that happens, so that every
-            # box sampled is a real part of the pupil and never worse than
-            # the box shared by every field point.
+            # the single bounding box shared by every field point
             axis_both = (axis_field, axis_pupil)
             global_min = pupil.min(axis=axis_both)
             global_max = pupil.max(axis=axis_both)
 
-            def bound(
-                lo: na.AbstractScalar,
-                hi: na.AbstractScalar,
-                lo_global: na.AbstractScalar,
-                hi_global: na.AbstractScalar,
-            ) -> tuple[na.AbstractScalar, na.AbstractScalar]:
-                lo = np.maximum(lo, lo_global)
-                hi = np.minimum(hi, hi_global)
-                bad = hi <= lo
-                return np.where(bad, lo_global, lo), np.where(bad, hi_global, hi)
+            if pupil_fit is None:
+                # There is no pupil resolved per field point to draw on, so
+                # every field point takes the shared box, as it did before
+                # the pupil was resolved per field.
+                min_pupil = global_min
+                max_pupil = global_max
 
-            min_x, max_x = bound(fit_min.x, fit_max.x, global_min.x, global_max.x)
-            min_y, max_y = bound(fit_min.y, fit_max.y, global_min.y, global_max.y)
-            min_pupil = na.Cartesian2dVectorArray(x=min_x, y=min_y)
-            max_pupil = na.Cartesian2dVectorArray(x=max_x, y=max_y)
+            else:
+                # The pupil is the one belonging to each field point,
+                # evaluated from the fit, rather than the shared box, which
+                # for an off-axis system can be many times larger than the
+                # pupil of any one of them.
+                fit_min, fit_max = pupil_fit
+                x = optika.vectors.SceneVectorArray(result.wavelength, result.field)
+                fit_min = fit_min(x).outputs
+                fit_max = fit_max(x).outputs
+
+                # No field point can accept more than the union of every ray
+                # which passes both stops, so bound the pupil of each field
+                # point to that.  A system limited by its field stop rather
+                # than its pupil stop has no smooth pupil for the fit to
+                # follow, and its box then collapses or turns inside out
+                # under the bound; fall back to the whole pupil wherever that
+                # happens, so that every box sampled is a real part of the
+                # pupil and never worse than the shared box.
+                def bound(
+                    lo: na.AbstractScalar,
+                    hi: na.AbstractScalar,
+                    lo_global: na.AbstractScalar,
+                    hi_global: na.AbstractScalar,
+                ) -> tuple[na.AbstractScalar, na.AbstractScalar]:
+                    lo = np.maximum(lo, lo_global)
+                    hi = np.minimum(hi, hi_global)
+                    bad = hi <= lo
+                    return np.where(bad, lo_global, lo), np.where(bad, hi_global, hi)
+
+                min_x, max_x = bound(fit_min.x, fit_max.x, global_min.x, global_max.x)
+                min_y, max_y = bound(fit_min.y, fit_max.y, global_min.y, global_max.y)
+                min_pupil = na.Cartesian2dVectorArray(x=min_x, y=min_y)
+                max_pupil = na.Cartesian2dVectorArray(x=max_x, y=max_y)
 
             result.pupil = (max_pupil - min_pupil) * (result.pupil + 1) / 2 + min_pupil
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -968,6 +968,18 @@ class AbstractSequentialSystem(
             aim=aim,
         )
 
+        # The solver fixes the free component of each ray in the local
+        # coordinates of the launch surface, so a launch surface which is
+        # translated along the axis leaves the rays on the right lines but at
+        # the wrong depth.  Carry them to the launch surface itself, as the
+        # stops are, so that their positions are on the object where the
+        # entrance pupil is measured.
+        rays = optika.propagators.propagate_rays(
+            propagators=[subsystem[0]],
+            rays=rays,
+            efficiency=False,
+        )
+
         # The solved component carries the pupil-stop axis and the fixed one
         # only the field axes, so broadcast them against each other to keep
         # reductions over either well-defined downstream.

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1117,6 +1117,10 @@ def test_pupil_denormalization_falls_back_to_the_shared_box(monkeypatch):
 
     monkeypatch.setattr(type(a), "_calc_rayfunction_pupil", fail)
 
+    # `a` is shared with the other tests in this module, so an earlier one may
+    # already have calibrated and cached its pupil
+    monkeypatch.delitem(a.__dict__, "pupil_fit", raising=False)
+
     wavelength = a.grid_input.wavelength
     stops = a._calc_rayfunction_stops(wavelength)
     assert a._calc_pupil_fit(wavelength, stops) is None

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -307,18 +307,27 @@ class AbstractTestAbstractSequentialSystem(
     ):
         """
         Moving every surface of a system together describes the same
-        instrument in a different frame, so it must leave every result of that
-        system alone.
+        instrument in a different frame, so :meth:`rayfunction` must return
+        what it did before.
 
-        Each result is measured in a frame the system carries with it: the
-        field and the pupil in the frame of the object, and the rays in the
-        frame of the sensor. Any of them measured in the global frame instead
-        moves with the motion, and any solve anchored to the global frame
-        finds a different answer, so this exercises every frame the system
-        works in at once. It is an invariance rather than a system built at an
-        angle on purpose, since tilting one surface of a system changes the
-        instrument and can quietly stop any light reaching the sensor, which
-        no amount of broken frame handling would then make worse.
+        Specifically: the field and the pupil it was traced at, the position
+        and the direction of every ray, and which rays were vignetted. Each is
+        measured in a frame the system carries with it, the first two in the
+        frame of the object and the rays in the frame of the sensor, so any of
+        them measured in the global frame instead moves with the motion, and
+        any solve anchored to the global frame finds a different answer. That
+        exercises every frame the system works in at once.
+
+        It is an invariance rather than a system built at an angle on purpose,
+        since tilting one surface of a system changes the instrument and can
+        quietly stop any light reaching the sensor, which no amount of broken
+        frame handling would then make worse.
+
+        What this does not cover: :meth:`raytrace`, whose output is global and
+        so moves with the motion rather than staying put, though it is pinned
+        indirectly, since the sensor frame these rays are in is the moved
+        sensor's; and the three models fit from these rays, which
+        :func:`test_models_are_invariant_under_a_rigid_motion` takes.
         """
         b = _moved_rigidly(a, _motion_rigid)
 
@@ -336,6 +345,7 @@ class AbstractTestAbstractSequentialSystem(
             (result.inputs.field, expected.inputs.field),
             (result.inputs.pupil, expected.inputs.pupil),
             (result.outputs.position, expected.outputs.position),
+            (result.outputs.direction, expected.outputs.direction),
         ]:
             error = (r - e).length.max()
             assert error < 1e-6 * e.length.max()
@@ -1289,6 +1299,55 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     position = a.object.transformation(rays.outputs.position)
 
     assert np.allclose(position.z, shift)
+
+
+def test_models_are_invariant_under_a_rigid_motion():
+    """
+    The three models fit from a raytrace survive a rigid motion of the whole
+    system, in the same way and for the same reason the rays do.
+
+    Fit on one system rather than on all of them, since these need a
+    wavelength grid on an axis of its own which not every system in this
+    module has, and each one costs a raytrace of its own.
+
+    The grid stops short of the edge of the field, for a sharper reason than
+    :func:`AbstractTestAbstractSequentialSystem.test_rayfunction_is_invariant_under_a_rigid_motion`
+    has. Both models fit through a mask built from ``unvignetted``, so a ray
+    which the roundoff of a motion carries across an aperture edge does not
+    merely move, it joins or leaves the fitted set, and a vignetted ray landed
+    wherever it landed. Measured on the grazing system with a grid running to
+    the edge, that moves the distortion model by 94 pixels and the
+    illumination by more than unity, while an interior grid holds both to
+    1e-7. Which is a fact about sampling on aperture edges rather than about
+    frames, and the reason :obj:`_grid_field_rigid` stops short as well.
+    """
+    a = _system_grazing
+    b = _moved_rigidly(a, _motion_rigid)
+
+    wavelength = na.linspace(500, 600, axis="_rigid_wavelength", num=3) * u.nm
+    kwargs = dict(
+        wavelength=wavelength,
+        field=_grid_field_rigid,
+        pupil=_grid_pupil_rigid,
+        degree=1,
+    )
+
+    distortion_a = a.distortion(**kwargs)
+    distortion_b = b.distortion(**kwargs)
+    sensor_a = distortion_a.coordinates_sensor
+    sensor_b = distortion_b.coordinates_sensor
+    assert (sensor_b - sensor_a).length.max() < 1e-6 * sensor_a.length.max()
+
+    vignetting_a = a.vignetting(**kwargs)
+    vignetting_b = b.vignetting(**kwargs)
+    illumination_a = vignetting_a.illumination
+    illumination_b = vignetting_b.illumination
+    assert np.abs(illumination_b - illumination_a).max() < 1e-6
+
+    # the sampling of this one is random, so hold it to a seed
+    area_a = a.area_effective(wavelength=wavelength, seed=42).area
+    area_b = b.area_effective(wavelength=wavelength, seed=42).area
+    assert np.abs(area_b - area_a).max() < 1e-6 * np.abs(area_a).max()
 
 
 def test_vignetting_weights_each_field_point_by_the_size_of_its_pupil():

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1480,30 +1480,6 @@ def test_pupil_calibration_does_not_swallow_an_unrelated_error(
         a._calc_pupil_fit(wavelength, stops)
 
 
-def test_pupil_fit_does_not_solve_the_stops_to_check_its_cache(monkeypatch):
-    """
-    Handing in stop rays of one's own does not make the system solve for its
-    own as well.
-
-    The cached fit is only good for the rays it was built from, so it is
-    returned only when those are the rays given. Asking the cached property
-    for them in order to compare would solve for them when the cache is cold,
-    which is the most expensive thing this class does.
-    """
-    a = dataclasses.replace(_system_newtonian)
-    wavelength = a.grid_input.wavelength
-    stops = a._calc_rayfunction_stops(wavelength)
-
-    # the cache is cold, and filling it now would be pure waste
-    assert "rayfunction_stops" not in a.__dict__
-
-    def fail(*args, **kwargs):
-        raise AssertionError("the stops were solved to compare against")
-
-    monkeypatch.setattr(type(a), "_calc_rayfunction_stops", fail)
-    a._pupil_fit(wavelength, stops)
-
-
 def test_pupil_denormalization_falls_back_when_a_corner_is_not_a_number():
     """
     A pupil corner which is not a number falls back to the box shared by every

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1135,6 +1135,35 @@ def test_pupil_denormalization_falls_back_to_the_shared_box(monkeypatch):
     assert np.any(rays.outputs.unvignetted)
 
 
+def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
+    """
+    The rays which find the pupil of a field point are launched from the
+    object surface itself, even when it is translated along the axis, since
+    the entrance pupil is measured on the object.
+
+    The solver fixes those rays in the local coordinates of the object, so a
+    translated object leaves them on the right lines but at the wrong depth
+    unless they are carried back to the object, which put the pupil of the
+    center of the field out of line with the pupil along its edge.
+    """
+    base = _system_newtonian
+    shift = -500 * u.mm
+    a = dataclasses.replace(
+        base,
+        object=dataclasses.replace(
+            base.object,
+            transformation=na.transformations.Cartesian3dTranslation(z=shift),
+        ),
+    )
+
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    field = a.field_boundary.mean(a.axis_stops)
+    rays = a._calc_rayfunction_pupil(wavelength, field, rayfunction_stops=stops)
+
+    assert np.allclose(rays.outputs.position.z, shift)
+
+
 def test_plot_unit():
     """
     The whole system is drawn in the unit asked for, rays included.

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1458,3 +1458,36 @@ def test_stops_and_pupil_are_solved_once_at_the_default_wavelength(monkeypatch):
 
     assert calls["stops"] == 2
     assert calls["fit"] == 2
+
+
+def test_pupil_denormalization_falls_back_when_the_fit_is_singular():
+    """
+    A field stop whose outline is degenerate in one component leaves the
+    least-squares fit of the pupil with a singular design matrix.  That is the
+    other way the calibration can fail, and like a field center which cannot
+    be traced it falls back to the box shared by every field point rather than
+    failing a raytrace which the shared box would have carried out.
+
+    The fit solves for its coefficients lazily, so forcing the solve is what
+    keeps this failure inside the fallback.
+    """
+    base = _system_newtonian
+    a = dataclasses.replace(
+        base,
+        object=dataclasses.replace(
+            base.object,
+            aperture=optika.apertures.RectangularAperture(
+                half_width=na.Cartesian2dVectorArray(
+                    x=np.sin(0.05 * u.deg),
+                    y=0 * u.dimensionless_unscaled,
+                ),
+            ),
+        ),
+    )
+
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    assert a._calc_pupil_fit(wavelength, stops) is None
+
+    rays = a.raytrace(accumulate=False)
+    assert np.any(rays.outputs.unvignetted)

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1110,16 +1110,15 @@ def test_pupil_denormalization_falls_back_to_the_shared_box(monkeypatch):
     denormalized onto the box shared by every field point, as it was before
     the pupil was resolved per field, instead of failing the raytrace.
     """
-    a = _system_newtonian
+    # A copy of the shared system, so that the `pupil_fit` this test caches on
+    # it, which is the fallback and not a real calibration, does not leak into
+    # whichever test happens to run next.
+    a = dataclasses.replace(_system_newtonian)
 
     def fail(*args, **kwargs):
         raise ValueError("the pupil of this field point cannot be found")
 
     monkeypatch.setattr(type(a), "_calc_rayfunction_pupil", fail)
-
-    # `a` is shared with the other tests in this module, so an earlier one may
-    # already have calibrated and cached its pupil
-    monkeypatch.delitem(a.__dict__, "pupil_fit", raising=False)
 
     wavelength = a.grid_input.wavelength
     stops = a._calc_rayfunction_stops(wavelength)
@@ -1415,3 +1414,47 @@ def test_area_effective_is_reproducible_when_seeded():
 
     assert np.all(a == b)
     assert np.any(a != c)
+
+
+def test_stops_and_pupil_are_solved_once_at_the_default_wavelength(monkeypatch):
+    """
+    Denormalizing a grid needs the stop rays and the entrance-pupil fit, and
+    both depend on nothing but the wavelength.  A caller working at the
+    system's own input wavelengths must pay for each of them once, however
+    many times it traces.
+    """
+    a = dataclasses.replace(_system_newtonian)
+
+    calls = dict(stops=0, fit=0)
+
+    solve_stops = type(a)._calc_rayfunction_stops
+    solve_fit = type(a)._calc_pupil_fit
+
+    def count_stops(self, *args, **kwargs):
+        calls["stops"] += 1
+        return solve_stops(self, *args, **kwargs)
+
+    def count_fit(self, *args, **kwargs):
+        calls["fit"] += 1
+        return solve_fit(self, *args, **kwargs)
+
+    monkeypatch.setattr(type(a), "_calc_rayfunction_stops", count_stops)
+    monkeypatch.setattr(type(a), "_calc_pupil_fit", count_fit)
+
+    grid = a.grid_input
+    for _ in range(3):
+        a.raytrace(field=grid.field, pupil=grid.pupil, accumulate=False)
+
+    assert calls["stops"] == 1
+    assert calls["fit"] == 1
+
+    # a wavelength the caches were not solved at is solved from scratch
+    a.raytrace(
+        wavelength=grid.wavelength + 1 * u.nm,
+        field=grid.field,
+        pupil=grid.pupil,
+        accumulate=False,
+    )
+
+    assert calls["stops"] == 2
+    assert calls["fit"] == 2

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1233,7 +1233,9 @@ def test_pupil_denormalization_falls_back_to_the_shared_box(monkeypatch):
     a = dataclasses.replace(_system_newtonian)
 
     def fail(*args, **kwargs):
-        raise ValueError("the pupil of this field point cannot be found")
+        raise optika.systems.StopSolveError(
+            "the pupil of this field point cannot be found"
+        )
 
     monkeypatch.setattr(type(a), "_calc_rayfunction_pupil", fail)
 
@@ -1320,6 +1322,60 @@ def test_pupil_fit_is_anchored_independently_of_the_stop_sampling():
     width = (hi_fine - lo_fine).length
     assert (lo_coarse - lo_fine).length < 1e-9 * width
     assert (hi_coarse - hi_fine).length < 1e-9 * width
+
+
+@pytest.mark.parametrize("stage", ["trace", "fit"])
+def test_pupil_calibration_does_not_swallow_an_unrelated_error(
+    monkeypatch,
+    stage: str,
+):
+    """
+    Only a solve which did not converge, or a design matrix which cannot be
+    inverted, falls back to the shared box.
+
+    Both fallbacks used to catch every :class:`ValueError`, which would turn a
+    system built wrong, or a mistake in the calibration itself, into a pupil
+    that silently stopped being resolved per field point, at either of the two
+    stages the calibration can fail at.
+    """
+    a = dataclasses.replace(_system_newtonian)
+
+    def fail(*args, **kwargs):
+        raise ValueError("this is neither of those")
+
+    if stage == "trace":
+        monkeypatch.setattr(type(a), "_calc_rayfunction_pupil", fail)
+    else:
+        monkeypatch.setattr(na.PolynomialFitFunctionArray, "from_degree", fail)
+
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    with pytest.raises(ValueError, match="neither of those"):
+        a._calc_pupil_fit(wavelength, stops)
+
+
+def test_pupil_fit_does_not_solve_the_stops_to_check_its_cache(monkeypatch):
+    """
+    Handing in stop rays of one's own does not make the system solve for its
+    own as well.
+
+    The cached fit is only good for the rays it was built from, so it is
+    returned only when those are the rays given. Asking the cached property
+    for them in order to compare would solve for them when the cache is cold,
+    which is the most expensive thing this class does.
+    """
+    a = dataclasses.replace(_system_newtonian)
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+
+    # the cache is cold, and filling it now would be pure waste
+    assert "rayfunction_stops" not in a.__dict__
+
+    def fail(*args, **kwargs):
+        raise AssertionError("the stops were solved to compare against")
+
+    monkeypatch.setattr(type(a), "_calc_rayfunction_stops", fail)
+    a._pupil_fit(wavelength, stops)
 
 
 def test_pupil_denormalization_falls_back_when_a_corner_is_not_a_number():

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1073,13 +1073,10 @@ def test_pupil_fit_resolves_the_entrance_pupil_per_field(
     stops = a._calc_rayfunction_stops(wavelength)
     fit_min, fit_max = a._calc_pupil_fit(wavelength, stops)
 
-    rays = stops.outputs
-    if a.object_is_at_infinity:
-        field = optika.angles(rays.direction)
-        pupil = rays.position.xy
-    else:
-        field = rays.position.xy
-        pupil = optika.angles(rays.direction)
+    # the field and pupil along the edge of both stops, in whichever of angle
+    # and position each is measured in for this object
+    field = a.field_boundary
+    pupil = a.pupil_boundary
 
     # the axis along the edge of the pupil stop, whichever stop axis the pupil
     # grid was swept over

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1104,6 +1104,37 @@ def test_pupil_fit_resolves_the_entrance_pupil_per_field(
     assert np.all(width_center.y < width.y)
 
 
+def test_pupil_denormalization_falls_back_to_the_shared_box(monkeypatch):
+    """
+    When the pupil of the center of the field cannot be found, the pupil is
+    denormalized onto the box shared by every field point, as it was before
+    the pupil was resolved per field, instead of failing the raytrace.
+    """
+    a = _system_newtonian
+
+    def fail(*args, **kwargs):
+        raise ValueError("the pupil of this field point cannot be found")
+
+    monkeypatch.setattr(type(a), "_calc_rayfunction_pupil", fail)
+
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    assert a._calc_pupil_fit(wavelength, stops) is None
+
+    # the pupil is the shared box, as it was before
+    grid = a.grid_input
+    result = a._denormalize_grid(grid)
+    pupil = a.pupil_boundary
+    axis = a.axis_stops
+    expected = pupil.ptp(axis) * (grid.pupil + 1) / 2 + pupil.min(axis)
+    assert np.allclose(result.pupil.x, expected.x)
+    assert np.allclose(result.pupil.y, expected.y)
+
+    # and the raytrace still runs on it
+    rays = a.raytrace(field=grid.field, pupil=grid.pupil, accumulate=False)
+    assert np.any(rays.outputs.unvignetted)
+
+
 def test_plot_unit():
     """
     The whole system is drawn in the unit asked for, rays included.

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1350,6 +1350,76 @@ def test_models_are_invariant_under_a_rigid_motion():
     assert np.abs(area_b - area_a).max() < 1e-6 * np.abs(area_a).max()
 
 
+def test_pupil_over_field_cells_holds_the_pupil_everywhere_in_the_cell():
+    """
+    The box a field cell is given holds the boxes at every one of its
+    vertices, so a ray drawn anywhere in the cell finds its whole pupil.
+
+    Averaging the vertices instead put the box at the cell's center, which the
+    pupil walks away from toward the cell's edges. Measured on ESIS at the
+    default 12 x 12 field, that took 0.57% off the effective area, against
+    0.02% with the union, and refining the pupil grid alone did nothing while
+    refining the field grid alone recovered most of it, which is the
+    signature of a box that clips per field cell.
+    """
+    axis_field = ("_fx", "_fy")
+    axis_pupil = ("_px", "_py")
+
+    # a pupil 10 mm wide which walks 4 mm in x across three field vertices,
+    # and 1 mm in y, on a 3-vertex pupil grid
+    walk = na.Cartesian2dVectorArray(
+        x=na.ScalarArray(np.array([0.0, 2.0, 4.0]), axes=("_fx",)),
+        y=na.ScalarArray(np.array([0.0, 1.0]), axes=("_fy",)),
+    )
+    normalized = na.Cartesian2dVectorLinearSpace(
+        start=-1,
+        stop=1,
+        axis=na.Cartesian2dVectorArray(*axis_pupil),
+        num=3,
+    )
+    pupil = (5 * normalized + walk) * u.mm
+
+    result = optika.systems.AbstractSequentialSystem._pupil_over_field_cells(
+        pupil=pupil,
+        axis_field=axis_field,
+        axis_pupil=axis_pupil,
+    )
+
+    # one fewer along each field axis, the pupil axes untouched
+    shape = na.shape(result)
+    assert shape["_fx"] == 2 and shape["_fy"] == 1
+    assert shape["_px"] == 3 and shape["_py"] == 3
+
+    lo = result.min(axis_pupil)
+    hi = result.max(axis_pupil)
+
+    # cell 0 spans the boxes at x-vertices 0 and 2 mm: [-5, 7]; cell 1: [-3, 9]
+    assert np.allclose(lo.x.ndarray, [-5, -3] * u.mm)
+    assert np.allclose(hi.x.ndarray, [7, 9] * u.mm)
+    # the one y cell spans the boxes at 0 and 1 mm: [-5, 6]
+    assert np.allclose(lo.y.ndarray, -5 * u.mm)
+    assert np.allclose(hi.y.ndarray, 6 * u.mm)
+
+    # the grid inside each box is the same normalized grid, not an average
+    inner = (result - lo) / (hi - lo)
+    expected = (normalized + 1) / 2
+    assert np.allclose(
+        inner.x.ndarray, expected.x.broadcast_to(na.shape(inner.x)).ndarray
+    )
+    assert np.allclose(
+        inner.y.ndarray, expected.y.broadcast_to(na.shape(inner.y)).ndarray
+    )
+
+    # a grid carrying no field axis is returned untouched
+    plain = 5 * normalized * u.mm
+    assert (
+        optika.systems.AbstractSequentialSystem._pupil_over_field_cells(
+            pupil=plain, axis_field=axis_field, axis_pupil=axis_pupil
+        )
+        is plain
+    )
+
+
 def test_vignetting_weights_each_field_point_by_the_size_of_its_pupil():
     """
     A field point which collects the same fraction of a pupil twice as wide

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1291,6 +1291,73 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     assert np.allclose(position.z, shift)
 
 
+def test_vignetting_weights_each_field_point_by_the_size_of_its_pupil():
+    """
+    A field point which collects the same fraction of a pupil twice as wide
+    collects four times the light, and the vignetting model says so.
+
+    :meth:`area_effective` weights by the area of each pupil cell and averages
+    the product over the field, so the two models multiply together to give
+    the light collected at one field point only if this one carries how large
+    that field point's pupil is.  Once the pupil is resolved per field point
+    that is no longer shared, which is what makes the weight necessary.
+
+    Every fixture in this module has a pupil whose area is the same across its
+    field, so the rays are built here rather than traced.
+    """
+    a = _system_newtonian
+
+    axis_wavelength = ("_vw",)
+    axis_field = ("_vfx", "_vfy")
+    axis_pupil = ("_vpx", "_vpy")
+
+    # the pupil of the second column of the field is twice as wide
+    width = na.ScalarArray(np.array([1.0, 2.0]), axes=("_vfx",))
+    pupil = (
+        na.Cartesian2dVectorLinearSpace(
+            start=-1,
+            stop=1,
+            axis=na.Cartesian2dVectorArray(*axis_pupil),
+            num=3,
+        )
+        * width
+        * u.mm
+    )
+
+    inputs = optika.vectors.ObjectVectorArray(
+        wavelength=na.linspace(500, 600, axis=axis_wavelength[0], num=2) * u.nm,
+        field=na.Cartesian2dVectorLinearSpace(
+            start=-1,
+            stop=1,
+            axis=na.Cartesian2dVectorArray(*axis_field),
+            num=2,
+        )
+        * u.deg,
+        pupil=pupil,
+    )
+    shape = na.shape_broadcasted(inputs.wavelength, inputs.field, inputs.pupil)
+    rays = optika.rays.RayFunctionArray(
+        inputs=inputs,
+        outputs=optika.rays.RayVectorArray(
+            unvignetted=na.broadcast_to(na.ScalarArray(np.array(True)), shape),
+        ),
+    )
+
+    model = a._fit_vignetting(
+        rays=rays,
+        axis_wavelength=axis_wavelength,
+        axis_field=axis_field,
+        axis_pupil=axis_pupil,
+        degree=1,
+    )
+
+    # every ray survives, so the whole difference is the size of the pupil
+    illumination = model.illumination
+    narrow = illumination[{"_vfx": 0}].mean()
+    wide = illumination[{"_vfx": 1}].mean()
+    assert np.allclose((wide / narrow).ndarray, 4)
+
+
 def test_pupil_fit_is_anchored_independently_of_the_stop_sampling():
     """
     The pupil the fit gives the center of the field does not depend on how

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1261,10 +1261,11 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     object surface itself, even when it is translated along the axis, since
     the entrance pupil is measured on the object.
 
-    The solver fixes those rays in the local coordinates of the object, so a
-    translated object leaves them on the right lines but at the wrong depth
-    unless they are carried back to the object, which put the pupil of the
-    center of the field out of line with the pupil along its edge.
+    A translated object used to leave them on the right lines but at the wrong
+    depth, which put the pupil of the center of the field out of line with the
+    pupil along its edge. What guarantees the depth now is that the solver
+    fixes each ray in the object's own coordinates and sets its z to the sag
+    there, so this pins the property rather than any one mechanism.
     """
     base = _system_newtonian
     shift = -500 * u.mm
@@ -1286,6 +1287,77 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     position = a.object.transformation(rays.outputs.position)
 
     assert np.allclose(position.z, shift)
+
+
+def test_pupil_fit_is_anchored_independently_of_the_stop_sampling():
+    """
+    The pupil the fit gives the center of the field does not depend on how
+    finely the stops were sampled to build it.
+
+    The fit is anchored on one interior sample taken at the center of the
+    field. The wire of an aperture closes, so its last point repeats its
+    first, and averaging the wire to find that center leans toward the
+    repeated point by one part in `samples_field_stop`, which would leave the
+    anchor, and so the whole calibration, a function of a sampling parameter.
+    """
+    a = _system_newtonian
+    wavelength = a.grid_input.wavelength
+
+    def pupil_at_the_center_of_the_field(samples: int):
+        stops = a._calc_rayfunction_stops(
+            wavelength_input=wavelength,
+            samples_field_stop=samples,
+            samples_pupil_stop=samples,
+        )
+        fit_min, fit_max = a._calc_pupil_fit(wavelength, stops)
+        field = na.Cartesian2dVectorArray(0, 0) * na.unit(a.field_boundary.x)
+        x = optika.vectors.SceneVectorArray(wavelength, field)
+        return fit_min(x).outputs, fit_max(x).outputs
+
+    lo_coarse, hi_coarse = pupil_at_the_center_of_the_field(11)
+    lo_fine, hi_fine = pupil_at_the_center_of_the_field(41)
+
+    width = (hi_fine - lo_fine).length
+    assert (lo_coarse - lo_fine).length < 1e-9 * width
+    assert (hi_coarse - hi_fine).length < 1e-9 * width
+
+
+def test_pupil_denormalization_falls_back_when_a_corner_is_not_a_number():
+    """
+    A pupil corner which is not a number falls back to the box shared by every
+    field point, in the same way a collapsed one does.
+
+    Testing the healthy case and negating it, rather than testing for the
+    broken one, is what makes this hold: a comparison against a NaN is false
+    either way round, so a guard written the other way would pass the NaN
+    through and turn every ray at that field point into a NaN silently.
+    """
+    a = dataclasses.replace(_system_newtonian)
+
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    fit_min, fit_max = a._calc_pupil_fit(wavelength, stops)
+
+    # poison the fit so that it evaluates to NaN at every field point
+    nan = np.nan * na.unit(fit_min.outputs.x)
+    fit_min = dataclasses.replace(
+        fit_min,
+        outputs=na.Cartesian2dVectorArray(x=nan, y=nan),
+    )
+    a.__dict__["pupil_fit"] = (fit_min, fit_max)
+
+    grid = a.grid_input
+    result = a._denormalize_grid(grid)
+
+    assert not np.any(np.isnan(result.pupil.x.ndarray))
+    assert not np.any(np.isnan(result.pupil.y.ndarray))
+
+    # the fallback is the shared box, exactly as when the fit is singular
+    pupil = a.pupil_boundary
+    axis = a.axis_stops
+    expected = pupil.ptp(axis) * (grid.pupil + 1) / 2 + pupil.min(axis)
+    assert np.allclose(result.pupil.x, expected.x)
+    assert np.allclose(result.pupil.y, expected.y)
 
 
 def test_solve_rays_launches_from_a_translated_surface():

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1056,6 +1056,57 @@ class TestSequentialSystemGrazingSpectrograph(
         assert np.abs(result.y - _radius_field_grazing) < 1e-6 * u.deg
 
 
+@pytest.mark.parametrize(
+    argnames="a",
+    argvalues=[_system_newtonian, _system_grazing],
+)
+def test_pupil_fit_resolves_the_entrance_pupil_per_field(
+    a: optika.systems.AbstractSequentialSystem,
+):
+    """
+    The entrance pupil is denormalized per field point, from a fit which
+    reproduces the pupil of every point along the edge of the field, and which
+    is narrower at the center of the field than the box shared by every field
+    point, since the pupil of these systems walks across the field.
+    """
+    wavelength = a.grid_input.wavelength
+    stops = a._calc_rayfunction_stops(wavelength)
+    fit_min, fit_max = a._calc_pupil_fit(wavelength, stops)
+
+    rays = stops.outputs
+    if a.object_is_at_infinity:
+        field = optika.angles(rays.direction)
+        pupil = rays.position.xy
+    else:
+        field = rays.position.xy
+        pupil = optika.angles(rays.direction)
+
+    # the axis along the edge of the pupil stop, whichever stop axis the pupil
+    # grid was swept over
+    axis_wire = tuple(ax for ax in a.axis_stops if ax in na.shape(stops.inputs.pupil))
+    axis_edge = tuple(ax for ax in a.axis_stops if ax not in axis_wire)
+
+    width = pupil.max(a.axis_stops) - pupil.min(a.axis_stops)
+    tolerance = 1e-5 * width
+
+    # the fit reproduces the pupil at every point along the edge of the field
+    field_edge = field.mean(axis_wire)
+    x = optika.vectors.SceneVectorArray(wavelength, field_edge)
+    error_min = np.abs(fit_min(x).outputs - pupil.min(axis_wire))
+    error_max = np.abs(fit_max(x).outputs - pupil.max(axis_wire))
+    assert np.all(error_min.x < tolerance.x)
+    assert np.all(error_min.y < tolerance.y)
+    assert np.all(error_max.x < tolerance.x)
+    assert np.all(error_max.y < tolerance.y)
+
+    # the pupil at the center of the field is narrower than the box shared by
+    # every field point
+    x_center = optika.vectors.SceneVectorArray(wavelength, field_edge.mean(axis_edge))
+    width_center = fit_max(x_center).outputs - fit_min(x_center).outputs
+    assert np.all(width_center.x < width.x)
+    assert np.all(width_center.y < width.y)
+
+
 def test_plot_unit():
     """
     The whole system is drawn in the unit asked for, rays included.

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -10,6 +10,80 @@ import optika
 from .._tests import test_mixins
 from ._systems_test import AbstractTestAbstractSystem
 
+_motion_rigid = na.transformations.compose(
+    na.transformations.Cartesian3dTranslation(
+        x=7 * u.mm,
+        y=-13 * u.mm,
+        z=29 * u.mm,
+    ),
+    na.transformations.compose(
+        na.transformations.Cartesian3dRotationZ(23 * u.deg),
+        na.transformations.Cartesian3dRotationY(17 * u.deg),
+    ),
+)
+"""
+A rigid motion used to describe a system in a different frame.
+
+The angles and distances are deliberately unrounded, so that a frame error
+cannot hide behind a symmetry of the system it is applied to, and moderate,
+so that no system is carried near the pole of the chart the launch solve
+parametrizes a ray direction on.
+"""
+
+
+def _moved_rigidly(
+    system: optika.systems.AbstractSequentialSystem,
+    motion: na.transformations.AbstractTransformation,
+) -> optika.systems.AbstractSequentialSystem:
+    """
+    Describe `system` in a frame moved by `motion`.
+
+    Every surface moves together, so this is a relabeling of the same
+    instrument rather than a different instrument, and every result of the
+    system must survive it unchanged.
+    :attr:`~optika.systems.AbstractSequentialSystem.transformation` already
+    carries onto every surface except the object, so moving the object is all
+    that is left to do.
+    """
+    obj = system.object
+    if obj is not None:
+        obj = dataclasses.replace(
+            obj,
+            transformation=na.transformations.compose(motion, obj.transformation),
+        )
+    return dataclasses.replace(
+        system,
+        object=obj,
+        transformation=na.transformations.compose(motion, system.transformation),
+    )
+
+
+_grid_field_rigid = na.Cartesian2dVectorLinearSpace(
+    start=-0.9,
+    stop=0.9,
+    axis=na.Cartesian2dVectorArray("_rigid_field_x", "_rigid_field_y"),
+    num=4,
+)
+"""
+The normalized field grid the rigid-motion test traces.
+
+It stops short of the edge of the field so that no ray lands exactly on the
+boundary of an aperture, where the roundoff a rigid motion introduces would
+decide which side of it the ray falls on.
+"""
+
+_grid_pupil_rigid = dataclasses.replace(
+    _grid_field_rigid,
+    axis=na.Cartesian2dVectorArray("_rigid_pupil_x", "_rigid_pupil_y"),
+)
+"""
+The normalized pupil grid the rigid-motion test traces.
+
+The same grid as :obj:`_grid_field_rigid` on its own pair of axes, so that the
+two sweep a four-dimensional grid instead of being broadcast against each
+other.
+"""
+
 
 class AbstractTestAbstractSequentialSystem(
     test_mixins.AbstractTestDxfWritable,
@@ -226,6 +300,49 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(raytrace.outputs, optika.rays.RayVectorArray)
         if accumulate:
             assert a.axis_surface in raytrace.shape
+
+    def test_rayfunction_is_invariant_under_a_rigid_motion(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        """
+        Moving every surface of a system together describes the same
+        instrument in a different frame, so it must leave every result of that
+        system alone.
+
+        Each result is measured in a frame the system carries with it: the
+        field and the pupil in the frame of the object, and the rays in the
+        frame of the sensor. Any of them measured in the global frame instead
+        moves with the motion, and any solve anchored to the global frame
+        finds a different answer, so this exercises every frame the system
+        works in at once. It is an invariance rather than a system built at an
+        angle on purpose, since tilting one surface of a system changes the
+        instrument and can quietly stop any light reaching the sensor, which
+        no amount of broken frame handling would then make worse.
+        """
+        b = _moved_rigidly(a, _motion_rigid)
+
+        kwargs = dict(
+            field=_grid_field_rigid,
+            pupil=_grid_pupil_rigid,
+        )
+        expected = a.rayfunction(**kwargs)
+        result = b.rayfunction(**kwargs)
+
+        # the field and the pupil are denormalized against the stops, which
+        # the system solves for in the frame of its object surface, and the
+        # rays are measured in the frame of the sensor
+        for r, e in [
+            (result.inputs.field, expected.inputs.field),
+            (result.inputs.pupil, expected.inputs.pupil),
+            (result.outputs.position, expected.outputs.position),
+        ]:
+            error = (r - e).length.max()
+            assert error < 1e-6 * e.length.max()
+
+        # no ray sits on the edge of an aperture, so the motion cannot move
+        # one across it and every ray must be vignetted exactly as before
+        assert np.all(result.outputs.unvignetted == expected.outputs.unvignetted)
 
     @pytest.mark.parametrize(
         argnames="wavelength,field,pupil",
@@ -1164,7 +1281,11 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     field = a.field_boundary.mean(a.axis_stops)
     rays = a._calc_rayfunction_pupil(wavelength, field, rayfunction_stops=stops)
 
-    assert np.allclose(rays.outputs.position.z, shift)
+    # these come back in the object's own coordinates, as the stop rays do, so
+    # carry them into the world's to say where the object actually is
+    position = a.object.transformation(rays.outputs.position)
+
+    assert np.allclose(position.z, shift)
 
 
 def test_solve_rays_launches_from_a_translated_surface():
@@ -1610,3 +1731,80 @@ def test_stops_solve_when_the_launch_surface_is_nearly_edge_on():
 
     # unreachable until the solve above stops raising, which is the point
     assert np.all(np.isfinite(result.outputs.position.length))  # pragma: nocover
+
+
+# the field stop is decentered so that a mirrored field frame is observable:
+# rays aimed using global-frame field bounds miss the aperture entirely
+_radius_field_rotated = 2 * u.mm
+_decenter_field_rotated = 3 * u.mm
+
+_system_rotated_object = optika.systems.SequentialSystem(
+    object=optika.surfaces.Surface(
+        name="source",
+        aperture=optika.apertures.CircularAperture(
+            radius=_radius_field_rotated,
+            transformation=na.transformations.Cartesian3dTranslation(
+                x=_decenter_field_rotated,
+            ),
+        ),
+        is_field_stop=True,
+        transformation=na.transformations.Cartesian3dRotationY(180 * u.deg),
+    ),
+    surfaces=[
+        optika.surfaces.Surface(
+            name="mirror",
+            sag=optika.sags.SphericalSag(radius=240 * u.mm),
+            material=optika.materials.Mirror(),
+            aperture=optika.apertures.CircularAperture(radius=15 * u.mm),
+            is_pupil_stop=True,
+            transformation=na.transformations.Cartesian3dTranslation(
+                z=-200 * u.mm,
+            ),
+        ),
+    ],
+    sensor=optika.sensors.ImagingSensor(
+        name="sensor",
+        width_pixel=150 * u.um,
+        axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
+        timedelta_exposure=1 * u.s,
+        num_pixel=na.Cartesian2dVectorArray(128, 128),
+        transformation=na.transformations.Cartesian3dTranslation(
+            z=100 * u.mm,
+        ),
+    ),
+    grid_input=_grid_input,
+)
+
+
+@pytest.mark.parametrize(argnames="a", argvalues=[_system_rotated_object])
+class TestSequentialSystemRotatedObject(
+    AbstractTestAbstractSequentialSystem,
+):
+    """
+    A finite-conjugate relay whose object surface is rotated 180 degrees
+    about :math:`y`, so its local coordinate frame differs from the global
+    frame. This guards the object-local frame handling of the stop
+    root-finding problem: the solved stop rays must be expressed in the
+    object surface's local coordinates before their direction is flipped,
+    since that is the frame in which the field and pupil coordinates of the
+    input grid are interpreted.
+    """
+
+    def test_field_bounds_match_decentered_aperture(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        x_min = _decenter_field_rotated - _radius_field_rotated
+        x_max = _decenter_field_rotated + _radius_field_rotated
+        assert np.abs(a.field_min.x - x_min) < 1 * u.um
+        assert np.abs(a.field_max.x - x_max) < 1 * u.um
+
+    def test_rays_reach_the_sensor(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        # the square field/pupil grids overfill the circular apertures, so
+        # the unvignetted fraction is well below 1 even for a healthy trace;
+        # with a mirrored object frame it is exactly 0
+        unvignetted = a.rayfunction_default.outputs.unvignetted
+        assert unvignetted.mean().ndarray > 0.25

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1164,6 +1164,40 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     assert np.allclose(rays.outputs.position.z, shift)
 
 
+def test_solve_rays_launches_from_a_translated_surface():
+    """
+    The rays the stop solver finds are launched from the surface it is given,
+    in global coordinates, even when that surface is translated along the
+    axis.  The solver fixes them in the local coordinates of that surface, so
+    it must carry every trial, and the result, into global coordinates, or a
+    translated surface launches them from the wrong depth and a ray with any
+    angle to the axis misses the surfaces it should strike.
+    """
+    base = _system_newtonian
+    shift = -500 * u.mm
+    a = dataclasses.replace(
+        base,
+        object=dataclasses.replace(
+            base.object,
+            transformation=na.transformations.Cartesian3dTranslation(z=shift),
+        ),
+    )
+
+    surfaces = a.surfaces_all
+    subsystem = surfaces[: a.index_pupil_stop + 1]
+    obj = subsystem[0]
+    pupil_stop = subsystem[~0]
+
+    grid_first = obj.aperture.wire(num=5)
+    grid_first = na.Cartesian2dVectorArray(grid_first.x, grid_first.y)
+    grid_last = pupil_stop.aperture.wire(num=5)
+    grid_last = na.Cartesian2dVectorArray(grid_last.x, grid_last.y)
+
+    rays = a._solve_rays(subsystem, grid_first, grid_last, a.grid_input.wavelength)
+
+    assert np.allclose(rays.position.z, shift)
+
+
 def test_plot_unit():
     """
     The whole system is drawn in the unit asked for, rays included.

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1491,3 +1491,122 @@ def test_pupil_denormalization_falls_back_when_the_fit_is_singular():
 
     rays = a.raytrace(accumulate=False)
     assert np.any(rays.outputs.unvignetted)
+
+
+def _system_with_launch_surface(transformation, fold: bool = False):
+    """
+    A system whose pupil stop comes first and carries a physical aperture, so
+    that the solver's free variable is the launch direction, with that stop
+    placed by the given transformation.
+
+    With `fold`, a 45 degree mirror ahead of the stop turns the beam onto the
+    world's :math:`x` axis, and the surfaces after the stop are placed along
+    that axis instead.
+    """
+    turn = na.transformations.Cartesian3dRotationY(90 * u.deg)
+
+    mirror = optika.surfaces.Surface(
+        name="mirror",
+        sag=optika.sags.SphericalSag(radius=-600 * u.mm),
+        material=optika.materials.Mirror(),
+        aperture=optika.apertures.CircularAperture(60 * u.mm),
+        transformation=(
+            (na.transformations.Cartesian3dTranslation(x=400 * u.mm) @ turn)
+            if fold
+            else na.transformations.Cartesian3dTranslation(z=300 * u.mm)
+        ),
+    )
+
+    stop = optika.surfaces.Surface(
+        name="stop",
+        aperture=optika.apertures.CircularAperture(15 * u.mm),
+        transformation=transformation,
+        is_pupil_stop=True,
+    )
+
+    fold_mirror = optika.surfaces.Surface(
+        name="fold",
+        material=optika.materials.Mirror(),
+        aperture=optika.apertures.CircularAperture(40 * u.mm),
+        transformation=na.transformations.Cartesian3dRotationY(-45 * u.deg),
+    )
+
+    return optika.systems.SequentialSystem(
+        object=optika.surfaces.Surface(
+            name="object",
+            aperture=optika.apertures.CircularAperture(np.sin(0.5 * u.deg)),
+            transformation=na.transformations.Cartesian3dTranslation(z=-400 * u.mm),
+        ),
+        surfaces=([fold_mirror] if fold else []) + [stop, mirror],
+        sensor=optika.sensors.ImagingSensor(
+            name="sensor",
+            width_pixel=10 * u.um,
+            axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
+            num_pixel=na.Cartesian2dVectorArray(256, 256),
+            transformation=(
+                (na.transformations.Cartesian3dTranslation(x=100 * u.mm) @ turn)
+                if fold
+                else None
+            ),
+            is_field_stop=True,
+        ),
+        grid_input=optika.vectors.ObjectVectorArray(
+            wavelength=500 * u.nm,
+            field=na.Cartesian2dVectorLinearSpace(
+                start=-1,
+                stop=1,
+                axis=na.Cartesian2dVectorArray("field_x", "field_y"),
+                num=3,
+            ),
+            pupil=na.Cartesian2dVectorLinearSpace(
+                start=-1,
+                stop=1,
+                axis=na.Cartesian2dVectorArray("pupil_x", "pupil_y"),
+                num=3,
+            ),
+        ),
+    )
+
+
+def test_stops_solve_with_a_folded_beam():
+    """
+    A 45 degree fold ahead of the pupil stop, so that the beam reaching it runs
+    along the world's :math:`x` axis rather than its :math:`z` axis.
+
+    The launch rays are solved in the local coordinates of the surface they are
+    launched from, where that beam runs along the surface's own normal.
+    Solving in world coordinates instead puts the parametrisation of the free
+    direction exactly on its pole here, since the beam is then perpendicular to
+    the axis the two free components are measured against.
+    """
+    a = _system_with_launch_surface(
+        na.transformations.Cartesian3dTranslation(x=150 * u.mm)
+        @ na.transformations.Cartesian3dRotationY(90 * u.deg),
+        fold=True,
+    )
+    result = a._calc_rayfunction_stops(500 * u.nm)
+    assert np.all(np.isfinite(result.outputs.position.length))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The free direction is parametrised by its two transverse components "
+        "in the local frame of the launch surface, which is singular when the "
+        "beam grazes that surface.  No two-parameter chart of the sphere is "
+        "regular everywhere, so the fix is to anchor the chart to the seed "
+        "direction, where the solution is known to lie."
+    ),
+)
+def test_stops_solve_when_the_launch_surface_is_nearly_edge_on():
+    """
+    A launch surface turned nearly edge-on to the beam, as a grazing-incidence
+    optic modelled as a tilted segment would be.
+    """
+    a = _system_with_launch_surface(
+        na.transformations.Cartesian3dRotationY(88 * u.deg),
+    )
+    result = a._calc_rayfunction_stops(500 * u.nm)
+
+    # unreachable until the solve above stops raising, which is the point
+    assert np.all(np.isfinite(result.outputs.position.length))  # pragma: nocover


### PR DESCRIPTION
This PR does two things, the second of which came out of the first. It also
carries #198 and #228, both merged into this branch, and supersedes the
abandoned draft #189.

# Part one: denormalize the entrance pupil per field point

## Motivation

The entrance pupil of an off-axis system walks across the field, but `_denormalize_grid_from_rays` maps a normalized pupil grid onto a single bounding box shared by every field point (`min`/`ptp` over both stop axes). Where that box is much larger than any one field point's pupil, much of the sampled pupil grid simply vignettes.

On the ESIS design the pupil is ~45 mm wide and walks ~12 mm, so the shared box has ~1.6x the area of any single field point's pupil. Measured apples-to-apples on a 7x7x7x7 grid, the unvignetted fraction goes from **0.098 on `main` to 0.158** here, a 1.61x gain that matches the bounding-box geometry exactly.

## Change

- **`_calc_pupil_fit`** fits the lower-left and upper-right corners of the entrance pupil as a degree-2 polynomial in field. The samples are the rays which graze both stops along the edge of the field (already solved by `rayfunction_stops`, so free) plus one through the center of the field stop, solved along with them. The center sample matters twice over: the edge of a round field lies on a single conic, along which a quadratic cannot tell a constant from a radial term, and it is also what captures a pupil that shrinks toward the field edge.
- **`_solve_rays`**: the stop solver, extracted from `_calc_rayfunction_stops_only`. The sample at the center of the field is not traced on its own: the center of the field stop is one more point on that stop, so it rides through the same solve between the two stops as one more point on the field stop's wire and is carried back to the object with the rest (cached as `_rayfunction_stops_with_center`). `rayfunction_stops` leaves it out, since it is not part of the outline of the field.
- **`_denormalize_grid_from_rays`** takes the fit and evaluates it at each field point. The fit depends on nothing but the wavelengths, so `linearize` computes it once alongside `stops` and hands both of its grids a physical pupil: the solve-once invariant from #211 is preserved.
- **`area_effective`**: samples its grids in normalized coordinates and denormalizes afterwards, so that every ray gets the entrance pupil of its own field position and is weighted by the area of its cell there; see *Accuracy* below. `linearize` hands it the solved stops through `_calc_area_effective`, keeping the solve-once invariant.

## Robustness

Three guards keep this strictly no worse than the shared box:

- Each field point's pupil is **bounded** by the union of every ray which passes both stops.
- A system limited by its *field* stop rather than its pupil stop has no smooth per-field pupil for the fit to follow (test fixture `a2`: a 20 mm mirror marked the pupil stop, but a 1.9 mm sensor 1 mm from the object does the limiting). There the bounded box collapses or inverts, and wherever that happens it **falls back to the shared box**.
- If the fit is singular, which a field stop degenerate in one component makes it, `_calc_pupil_fit` returns `None` and the pupil is denormalized onto the shared box exactly as before, rather than failing a raytrace the shared box would have carried out. The per-field pupil is an optimization, never a requirement.

Systems that are not off-axis see a no-op, since their per-field box already sits inside the shared one.

## Two solver bugs found on the way, via the FURST design

Testing against FURST (solar disk at z = -1300 mm, a 3 mm-radius cylindrical feed mirror, grating pupil stop) exposed two bugs in how the stop solver handles a launch surface **translated along the axis**. Both are invisible on ESIS and every in-repo fixture, whose launch surfaces sit at z = 0.

- **`main`'s stop solver traced every trial ray from the launch surface's local depth.** `_ray_error` overwrote the trial position with the launch surface's local coordinates (z = local sag) on a ray already in global coordinates and never transformed it. The seed, correctly aimed for the true depth, then missed small surfaces by `dx * dz` for any off-axis field (on FURST a 6 mm miss on a 3 mm cylinder, hence a NaN residual and "Could not solve"), while the on-axis field converged. This is latent on `main` for any translated stop surface. Fixed by keeping the rays local during the solve, carrying each trial into global coordinates in `_ray_error`, and carrying the result there once at the end. With this fix FURST's stops converge as written (sun as field stop, grating as pupil stop).
- **The per-field center sample was measured at that wrong depth**, out of line with the edge samples measured on the object, dragging the fit's intercept off by `dx * dz` (0.289 mm against a 52 um pupil strip on FURST). That trace no longer exists; the center sample now comes from the stop solve and reaches the object with every other stop ray.

# Part two: measure every result in the frame the system carries with it

Chasing the two bugs above turned up a pattern rather than a pair of accidents. Three of the system's results are measured in a frame the system carries with it rather than in the world: the field and the pupil in the object surface's frame, and the rays returned by `rayfunction` in the sensor's. Each was partly measured in the global frame instead.

- **The stop rays are now expressed in the object's frame before their direction is flipped**, which is the frame the input grid's field and pupil are read in. This is #198, merged here.
- **`_calc_pupil_fit` was fitting across two frames.** Its edge samples come from the stop rays and its interior sample is traced separately, and those stopped agreeing once the stop rays became object-local, so the fit was trained on a centre sample taken at a different field point than its edges. Only the `bound()` clamp kept that from doing visible damage. Since then the interior sample has moved into the stop solve itself, so the two cannot disagree, and `_solve_rays` no longer takes an `aim`.
- **`rayfunction` was not in the sensor's frame.** It un-transformed its result by the sensor's own transformation and not by the system's, but `surfaces_all` places the sensor with both composed, so a system with a `transformation` reported rays in neither the sensor's frame nor the global one. Every one of the 5489 unvignetted rays of `esis.flights.f1.optics.design_single` landed **outside the sensor's own aperture**, `|y|` reaching 52 mm against a 7.8 mm half width, because the rays kept that channel's roll. All 5489 are inside it now. The multi-channel `design` and the FURST design are unaffected, both having an identity system transformation.

## Testing the frame conventions instead of trusting them

Every fixture in `_sequential_test.py` placed its surfaces with translations alone. That is exactly the invariance which hid all of these: a quantity measured in the global frame by mistake is indistinguishable from one measured in the object's frame until something is rotated.

The obvious repair, a fixture built at an angle, does not work. Rotating one surface changes the *instrument* rather than the description of it, and at any useful angle it stops light reaching the sensor, so the test passes on broken code for the wrong reason. Measured on `_system_newtonian`, rotating the object by one degree leaves zero surviving rays whether the frame handling is right or wrong.

`test_rayfunction_is_invariant_under_a_rigid_motion` moves every surface together instead. That describes the same instrument in a different frame, so the field, the pupil, the ray positions and the vignetted set must all come back unchanged, and each of them is measured in a frame the system carries with it. It runs against all nine systems in the module and adds about 13 s.

The traced grid stops short of the edge of the field so no ray sits on the boundary of an aperture, where the roundoff a rigid motion introduces would decide which side of it the ray falls on. With that, the vignetted set matches exactly rather than to within a tolerance.

**It discriminates.** Reverting each frame fix in turn:

| fix reverted | new test |
| --- | --- |
| launch-surface frame (`_ray_error`) | 9 of 9 fail |
| stop rays in the object frame (#198) | 9 of 9 fail |
| pupil fit in the object frame | 8 of 9 fail |
| sensor frame | 9 of 9 fail |

As it stands the relative error is at worst 1.4e-9 and no ray changes its vignetting, on Linux, macOS and Windows. The real seven-channel FURST spectrograph passes it too, at 1e-14 to 6e-13 relative with zero flips across 5376 rays.

## Docs

`docs/stop_finding.rst` comes across from the abandoned #189, the only prose description of any of this and otherwise lost when that draft was closed. Updated: `_shoot_rays` renamed to `_solve_rays` throughout, a new section on the per-field entrance pupil and its three fallbacks, and a corrected statement of the frame conventions, which are now four rather than one, plus a note that the invariance test is what enforces them.

That last part is the general lesson. Nothing in the type system distinguishes rays in the object frame from rays in a launch surface's frame from rays in the sensor's frame from rays in the world frame, so every one of these bugs is silent and shows up only as a wrong number. The page now says which frame each function takes and returns, and there is a test which fails when one of them drifts.

# Accuracy of `area_effective`

Resolving the pupil per field point exposed an assumption in `area_effective`
which the shared box had been covering for. It draws each ray at a random
position inside its field cell but gave every ray in the cell one pupil box,
on the assumption that the pupil walks little enough across one cell for one
box to stand in. With 12 mm of slack in the shared box that was true. With a
box no larger than the pupil, one box per cell is wrong in one of two ways.
The box at the cell's center clips the rays drawn toward the cell's edges: on
ESIS, 0.6% of the effective area at the default 12 x 12 field. The union of
the boxes at the cell's vertices holds every ray's pupil but wastes the rays
outside it: on FURST, whose entrance pupil is a 0.09 mm sliver walking 20 mm
across the field, eight times its own width per cell, that union is ten
times the pupil and wastes nine rays in ten.

The fix draws the samples in normalized coordinates and denormalizes them
afterwards, so that each ray's pupil cell is mapped onto the entrance pupil
of the ray's own field position and weighted by the cell's area there. No
ray is clipped and none is wasted, there is no per-cell box to construct,
and the estimator is exactly what the docstring says it is.

Measured at the default grids, mean and seed-to-seed scatter over 40 seeds,
against a value converged on finer grids:

| effective area, default grids | ESIS f1 design | FURST design |
| --- | --- | --- |
| `main`, one shared box | 1.2746 +- 0.24% | **3.15 +- 2.2%** |
| union of the vertex boxes | 1.2745 +- 0.17% | 1.168 +- 0.33% |
| **this branch**, each ray its own pupil | 1.2738 +- 0.16% | **1.1636 +- 0.07%** |
| converged | 1.2738 +- 0.02% | 1.164 |

On FURST `main`'s default answer is 2.7x too high. With 0.27% of its rays
surviving, most field points get no surviving ray at all, are dropped from
the field average, and bias what remains; it needs a 48 x 48 pupil to come
within 0.5%, where this branch is within 0.05% at 12 x 12. On ESIS the three
schemes agree, and this branch's scatter is the lowest of the three, as it
should be with no ray wasted. One detail matters for that: the samples are
drawn independently along every axis of the system, such as ESIS's four
channels, which the physical grids used to carry for free and a normalized
grid does not; sharing them across channels raised the ESIS scatter to
0.26% before that was put back.

# Performance

Measured on ESIS flight-1 against `main` at `a21028d`, a fresh system per
repetition, median of three to five.

**The raytrace itself is faster**, and returns considerably more of what was
traced:

| ESIS f1 design | this branch | main |
| --- | --- | --- |
| raytrace, geometry only | **1205 ms** | 1733 ms |
| raytrace, with efficiency | **3104 ms** | 3631 ms |
| unvignetted fraction | **0.3213** | 0.1918 |

**The per-field pupil adds a calibration**, cached per system and per
wavelength grid. It began as a separate Newton solve from the object for the
pupil at the centre of the field, at 2487 ms, four times the whole stop
solve, because it worked through every surface between the object and the
pupil stop, twelve objective calls at 2676 µs per ray against the stop
solve's two at 169 µs. It now costs one more sample of the stop solve: the
centre of the field stop is a point on that stop like the points along its
edge, so it rides through the same solve between the two adjacent stops and
is carried back to the object with the rest.

| | this branch | main |
| --- | --- | --- |
| stops solve | 560 ms | 569 ms |
| pupil fit | **115 ms** (was 2487 ms) | not applicable |

End to end, cold, at the default `num_distribution=11`:

| `rayfunction_default`, `design` | this branch | main |
| --- | --- | --- |
| wall time | 4105 ms | 3920 ms |
| per surviving ray | **218 µs** | 349 µs |

So a cold call is 5% slower for 68% more surviving rays, and cheaper per ray
that survives. `linearize` on `design` at five wavelengths takes 22.6 s
against 19.6 s on `main`; 64% of it on either branch is `area_effective`'s
trace, which carries efficiency, and up to half of that is efficiency
computed on rays which are later vignetted, which is a follow-up outside this
PR.

# Tests

- `test_pupil_fit_resolves_the_entrance_pupil_per_field` (Newtonian, Grazing): the fit reproduces every field-edge pupil from the stops to 1e-5 of the pupil width, and the center pupil is strictly narrower than the shared box.
- `test_pupil_denormalization_falls_back_when_the_fit_is_singular`: with a field stop degenerate in one component the fit is singular, the pupil is the shared box and the raytrace still runs.
- `test_solve_rays_launches_from_a_translated_surface` and `test_pupil_of_the_center_of_the_field_is_measured_on_a_translated_object`: with the object translated 500 mm, the solver's rays and the per-field rays are launched from the object.
- `test_stops_solve_with_a_folded_beam`, plus an `xfail` pinning the known chart pole (#227) at a grazing launch surface.
- `test_rayfunction_is_invariant_under_a_rigid_motion` across all nine systems.
- `test_area_effective_gives_each_ray_the_pupil_of_its_own_field_point`: with a synthetic pupil walking a third of its width per field cell, every ray lies inside the box at its own field position and carries that box's cell area.
- Full `pytest optika`: 22490 passed, 304 skipped, 18 xfailed. ESIS unvignetted fraction unchanged at 0.158.

# Follow-ups, not blocking

- The `na.nominal(inputs)` workaround comes out once named-arrays cuts a release including sun-data/named-arrays#231, along with the `~=2.9` pin bump.
- #227 is the direction chart's pole, unrelated to these frames and deliberately left open.
- Anything calibrated against ESIS `design_single`'s old rolled sensor coordinates will shift.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc






