### PR TITLE
Let the vignetting and distortion models plot into axes they are given

### DIFF
--- a/optika/distortion/_distortion.py
+++ b/optika/distortion/_distortion.py
@@ -418,6 +418,7 @@ class PolynomialDistortionModel(
 
     def plot_residual(
         self,
+        ax: None | na.ScalarArray = None,
         figsize: None | tuple[float, float] = None,
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
@@ -434,6 +435,12 @@ class PolynomialDistortionModel(
 
         Parameters
         ----------
+        ax
+            The matplotlib axes to draw on, distributed along
+            :attr:`axis_wavelength`.
+            If :obj:`None`, a new figure is created with one subplot per
+            wavelength, and `figsize` sets its size.
+            If given, `figsize` is ignored, since the figure already exists.
         figsize
             The size of the returned figure in inches.
             If :obj:`None`, the size is chosen automatically from the number
@@ -468,26 +475,35 @@ class PolynomialDistortionModel(
 
         ncols = na.shape(wavelength).get(axis_wavelength, 1)
 
-        if figsize is None:
-            # shape each subplot to the field-of-view aspect ratio, and widen
-            # the figure to fit one subplot per wavelength
-            height_subplot = 3
-            aspect = (position.x.ptp() / position.y.ptp()).ndarray.value
-            figsize = (
-                ncols * height_subplot * aspect + 1.5,
-                height_subplot + 1,
-            )
-
         with astropy.visualization.quantity_support():
-            fig, ax = na.plt.subplots(
-                axis_cols=axis_wavelength,
-                ncols=ncols,
-                sharex=True,
-                sharey=True,
-                squeeze=False,
-                figsize=figsize,
-                constrained_layout=True,
-            )
+            if ax is None:
+                if figsize is None:
+                    # shape each subplot to the field-of-view aspect ratio, and
+                    # widen the figure to fit one subplot per wavelength
+                    height_subplot = 3
+                    aspect = (position.x.ptp() / position.y.ptp()).ndarray.value
+                    figsize = (
+                        ncols * height_subplot * aspect + 1.5,
+                        height_subplot + 1,
+                    )
+
+                fig, ax = na.plt.subplots(
+                    axis_cols=axis_wavelength,
+                    ncols=ncols,
+                    sharex=True,
+                    sharey=True,
+                    squeeze=False,
+                    figsize=figsize,
+                    constrained_layout=True,
+                )
+            else:
+                ax = na.as_named_array(ax)
+                if axis_wavelength not in ax.shape:
+                    raise ValueError(
+                        f"the given axes must be distributed along "
+                        f"{axis_wavelength=}, got {ax.shape=}."
+                    )
+                fig = ax.ndarray.reshape(-1)[0].get_figure()
 
             colorizer = plt.Colorizer(
                 cmap=cmap,

--- a/optika/distortion/_distortion_test.py
+++ b/optika/distortion/_distortion_test.py
@@ -154,6 +154,47 @@ class TestPolynomialDistortionModel(
         assert a.axis_wavelength in na.shape(ax)
         plt.close(fig)
 
+    def test_plot_residual_ax(
+        self,
+        a: optika.distortion.PolynomialDistortionModel,
+    ):
+        """The plotter draws into axes given to it, instead of its own."""
+        axis = a.axis_wavelength
+        num = na.shape(a.coordinates_scene)[axis]
+
+        fig, ax = na.plt.subplots(
+            axis_rows="row",
+            nrows=2,
+            axis_cols=axis,
+            ncols=num,
+            squeeze=False,
+        )
+
+        row = ax[{"row": 0}]
+
+        fig_result, ax_result = a.plot_residual(ax=row)
+
+        assert fig_result is fig
+        assert np.all(ax_result == row)
+
+        # the row it was given has been drawn on, and the other has not
+        assert all(b.collections for b in row.ndarray)
+        assert not any(b.collections for b in ax[{"row": 1}].ndarray)
+
+        plt.close(fig)
+
+    def test_plot_residual_ax_invalid(
+        self,
+        a: optika.distortion.PolynomialDistortionModel,
+    ):
+        """Axes which are not distributed along the wavelength axis are refused."""
+        fig, ax = na.plt.subplots(axis_cols="wrong", ncols=2, squeeze=False)
+
+        with pytest.raises(ValueError, match="must be distributed along"):
+            a.plot_residual(ax=ax)
+
+        plt.close(fig)
+
 
 def test_polynomial_distortion_model_channel():
     """

--- a/optika/radiometry/_vignetting.py
+++ b/optika/radiometry/_vignetting.py
@@ -6,6 +6,7 @@ import matplotlib.cm
 import matplotlib.colors
 import matplotlib.figure
 import matplotlib.pyplot as plt
+import numpy as np
 import astropy.visualization
 import named_arrays as na
 import optika
@@ -242,13 +243,19 @@ class PolynomialVignettingModel(
             If :obj:`None`, defaults to zero.
         vmax
             The residual value mapped to the highest color.
-            If :obj:`None`, defaults to the maximum residual.
+            If :obj:`None`, defaults to the largest residual among the points
+            the fit was constrained by.
         kwargs
             Additional keyword arguments passed to
             :func:`named_arrays.plt.pcolormesh`.
         """
+        residual = abs(self.illumination - self.fit.predictions)
+
+        # exclude the calibration points that were not used by the fit
+        residual = np.where(self.where, residual, np.nan)
+
         return self._plot(
-            abs(self.illumination - self.fit.predictions),
+            residual,
             label="illumination residual",
             ax=ax,
             figsize=figsize,
@@ -329,7 +336,7 @@ class PolynomialVignettingModel(
         if vmin is None:
             vmin = 0
         if vmax is None:
-            vmax = values.max()
+            vmax = np.nanmax(values)
 
         ncols = na.shape(wavelength).get(axis_wavelength, 1)
 

--- a/optika/radiometry/_vignetting.py
+++ b/optika/radiometry/_vignetting.py
@@ -139,10 +139,20 @@ class PolynomialVignettingModel(
             degree=1,
         )
 
-        fig, ax = model.plot()
-        na.plt.set_aspect("equal", ax=ax);
+        fig, ax = na.plt.subplots(
+            axis_rows="row",
+            nrows=2,
+            axis_cols="wavelength",
+            ncols=3,
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+            constrained_layout=True,
+        )
 
-        fig, ax = model.plot_residual()
+        model.plot(ax=ax[{"row": 1}])
+        model.plot_residual(ax=ax[{"row": 0}])
+
         na.plt.set_aspect("equal", ax=ax);
     """
 
@@ -198,6 +208,7 @@ class PolynomialVignettingModel(
 
     def plot_residual(
         self,
+        ax: None | na.ScalarArray = None,
         figsize: None | tuple[float, float] = None,
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
@@ -214,6 +225,12 @@ class PolynomialVignettingModel(
 
         Parameters
         ----------
+        ax
+            The matplotlib axes to draw on, distributed along
+            :attr:`axis_wavelength`.
+            If :obj:`None`, a new figure is created with one subplot per
+            wavelength, and `figsize` sets its size.
+            If given, `figsize` is ignored, since the figure already exists.
         figsize
             The size of the returned figure in inches.
             If :obj:`None`, the size is chosen automatically from the number
@@ -233,6 +250,7 @@ class PolynomialVignettingModel(
         return self._plot(
             abs(self.illumination - self.fit.predictions),
             label="illumination residual",
+            ax=ax,
             figsize=figsize,
             cmap=cmap,
             vmin=vmin,
@@ -242,6 +260,7 @@ class PolynomialVignettingModel(
 
     def plot(
         self,
+        ax: None | na.ScalarArray = None,
         figsize: None | tuple[float, float] = None,
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
@@ -254,6 +273,12 @@ class PolynomialVignettingModel(
 
         Parameters
         ----------
+        ax
+            The matplotlib axes to draw on, distributed along
+            :attr:`axis_wavelength`.
+            If :obj:`None`, a new figure is created with one subplot per
+            wavelength, and `figsize` sets its size.
+            If given, `figsize` is ignored, since the figure already exists.
         figsize
             The size of the returned figure in inches.
             If :obj:`None`, the size is chosen automatically from the number
@@ -273,6 +298,7 @@ class PolynomialVignettingModel(
         return self._plot(
             self.illumination,
             label="illumination",
+            ax=ax,
             figsize=figsize,
             cmap=cmap,
             vmin=vmin,
@@ -284,6 +310,7 @@ class PolynomialVignettingModel(
         self,
         values: na.AbstractScalar,
         label: str,
+        ax: None | na.ScalarArray = None,
         figsize: None | tuple[float, float] = None,
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
@@ -306,26 +333,35 @@ class PolynomialVignettingModel(
 
         ncols = na.shape(wavelength).get(axis_wavelength, 1)
 
-        if figsize is None:
-            # shape each subplot to the field-of-view aspect ratio, and widen
-            # the figure to fit one subplot per wavelength
-            height_subplot = 3
-            aspect = (position.x.ptp() / position.y.ptp()).ndarray.value
-            figsize = (
-                ncols * height_subplot * aspect + 1.5,
-                height_subplot + 1,
-            )
-
         with astropy.visualization.quantity_support():
-            fig, ax = na.plt.subplots(
-                axis_cols=axis_wavelength,
-                ncols=ncols,
-                sharex=True,
-                sharey=True,
-                squeeze=False,
-                figsize=figsize,
-                constrained_layout=True,
-            )
+            if ax is None:
+                if figsize is None:
+                    # shape each subplot to the field-of-view aspect ratio, and
+                    # widen the figure to fit one subplot per wavelength
+                    height_subplot = 3
+                    aspect = (position.x.ptp() / position.y.ptp()).ndarray.value
+                    figsize = (
+                        ncols * height_subplot * aspect + 1.5,
+                        height_subplot + 1,
+                    )
+
+                fig, ax = na.plt.subplots(
+                    axis_cols=axis_wavelength,
+                    ncols=ncols,
+                    sharex=True,
+                    sharey=True,
+                    squeeze=False,
+                    figsize=figsize,
+                    constrained_layout=True,
+                )
+            else:
+                ax = na.as_named_array(ax)
+                if axis_wavelength not in ax.shape:
+                    raise ValueError(
+                        f"the given axes must be distributed along "
+                        f"{axis_wavelength=}, got {ax.shape=}."
+                    )
+                fig = ax.ndarray.reshape(-1)[0].get_figure()
 
             colorizer = plt.Colorizer(
                 cmap=cmap,

--- a/optika/radiometry/_vignetting_test.py
+++ b/optika/radiometry/_vignetting_test.py
@@ -203,3 +203,39 @@ def test_polynomial_vignetting_model_channel():
     result = a(scene)
     assert "channel" in result.shape
     assert np.all(np.abs(result - illumination) < 1e-9)
+
+
+def test_plot_residual_where():
+    """
+    The residual is undefined at the calibration points the fit was not
+    constrained by, so those are left out rather than drawn, and the default
+    color scale is set without them.
+    """
+    scene = _scene()
+    illumination = _illumination()
+
+    # the corners of the field are excluded from the fit
+    where = scene.position.length < 1.2 * u.deg
+
+    a = optika.radiometry.PolynomialVignettingModel(
+        coordinates_scene=scene,
+        illumination=illumination,
+        axis_wavelength="wavelength",
+        axis_field=("field_x", "field_y"),
+        degree=1,
+        where=where,
+    )
+
+    residual = abs(a.illumination - a.fit.predictions)
+    residual_inside = np.nanmax(residual[where].ndarray)
+
+    # the excluded corners hold the largest residuals, so had they been kept
+    # they would have set the upper limit of the color scale
+    assert residual_inside < np.nanmax(residual.ndarray)
+
+    fig, ax = a.plot_residual()
+
+    norm = ax.ndarray.reshape(-1)[0].collections[0].norm
+    assert norm.vmax == pytest.approx(residual_inside)
+
+    plt.close(fig)

--- a/optika/radiometry/_vignetting_test.py
+++ b/optika/radiometry/_vignetting_test.py
@@ -128,6 +128,57 @@ class TestPolynomialVignettingModel(
         assert a.axis_wavelength in na.shape(ax)
         plt.close(fig)
 
+    @pytest.mark.parametrize(
+        argnames="method",
+        argvalues=["plot", "plot_residual"],
+    )
+    def test_plot_ax(
+        self,
+        a: optika.radiometry.PolynomialVignettingModel,
+        method: str,
+    ):
+        """Both plotters draw into axes given to them, instead of their own."""
+        axis = a.axis_wavelength
+        num = na.shape(a.coordinates_scene)[axis]
+
+        fig, ax = na.plt.subplots(
+            axis_rows="row",
+            nrows=2,
+            axis_cols=axis,
+            ncols=num,
+            squeeze=False,
+        )
+
+        row = ax[{"row": 0}]
+
+        fig_result, ax_result = getattr(a, method)(ax=row)
+
+        assert fig_result is fig
+        assert np.all(ax_result == row)
+
+        # the row it was given has been drawn on, and the other has not
+        assert all(b.collections for b in row.ndarray)
+        assert not any(b.collections for b in ax[{"row": 1}].ndarray)
+
+        plt.close(fig)
+
+    @pytest.mark.parametrize(
+        argnames="method",
+        argvalues=["plot", "plot_residual"],
+    )
+    def test_plot_ax_invalid(
+        self,
+        a: optika.radiometry.PolynomialVignettingModel,
+        method: str,
+    ):
+        """Axes which are not distributed along the wavelength axis are refused."""
+        fig, ax = na.plt.subplots(axis_cols="wrong", ncols=2, squeeze=False)
+
+        with pytest.raises(ValueError, match="must be distributed along"):
+            getattr(a, method)(ax=ax)
+
+        plt.close(fig)
+
 
 def test_polynomial_vignetting_model_channel():
     """


### PR DESCRIPTION
`PolynomialVignettingModel.plot()`/`.plot_residual()` and `PolynomialDistortionModel.plot_residual()` each built their own figure, so there was no way to ask for two of them in one figure. Two separate figures also do not share axes, so the panels of one did not line up with the panels of the other, and each carried its own copy of the axis labels.

All three now take an `ax` parameter, as the rest of the library's plotting does. When it is passed, the figure is taken from the axes and `figsize` is ignored; when it is not, behaviour is unchanged. Axes that are not distributed along `axis_wavelength` are refused with a `ValueError`, since the plot puts one wavelength in each of them.

The vignetting class example now draws both panels into one shared 2×3 grid, which is what the parameter is for.

## A divergence between the two, and a behaviour change

Putting the two side by side turned up that they disagree. `PolynomialDistortionModel.plot_residual()` already excludes the calibration points the fit was not constrained by, and takes its default upper limit with `nanmax` so that excluding them means something:

```python
residual = np.where(self.where, residual, np.nan * unit)
...
if vmax is None:
    vmax = np.nanmax(residual)
```

`PolynomialVignettingModel.plot_residual()` did neither. So for a model with a non-trivial `where` — an instrument with a field stop, say — the points outside it, where no ray survives and the residual is the polynomial's prediction subtracted from nothing, were drawn as the largest values in the plot and set the color scale for everything else. And a caller who masked them itself got `vmax=nan` out of `values.max()`, and whatever fallback range matplotlib picks, which is not the data's.

The vignetting residual now does what the distortion residual does. **This changes what `plot_residual()` draws for any model whose `where` is not all true**, which is the point of it. Models with the default `where=True` are unaffected.

Found while porting the vignetting subsection of the ESIS instrument paper, which wanted the two-row layout and was carrying a `replace()` + explicit `vmax` workaround for the masking. Both go away.

## Tests

- `test_plot_ax` / `test_plot_residual_ax`, for all three plotters: the returned figure is the one that owns the given axes, the returned axes are the ones passed in, and only the row it was given has been drawn on.
- `test_plot_ax_invalid` / `test_plot_residual_ax_invalid`: the `ValueError`.
- `test_plot_residual_where`: with the corners of the field excluded from the fit, the default `vmax` is the largest residual among the points that *were* fit, not the larger one among those that were not.

650 pass across `optika/radiometry`, `optika/distortion`, and `optika/systems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYjDL98znSud1yFh9chnkP