### PR TITLE
Take the nearest root in `ParabolicSag.intercept`

### DIFF
--- a/optika/sags/_parabolic.py
+++ b/optika/sags/_parabolic.py
@@ -106,9 +106,12 @@ class ParabolicSag(
         .. math::
 
             d = \frac{-o_x u_x - o_y u_y + 2 f u_z
-                      - \text{sgn}(f u_z) \sqrt{-o_y^2 u_x^2 - o_x^2 u_y^2 + 2 o_y u_y (o_x u_x - 2 f u_z)
+                      \mp \sqrt{-o_y^2 u_x^2 - o_x^2 u_y^2 + 2 o_y u_y (o_x u_x - 2 f u_z)
                               + 4 f (o_z (u_x^2 + u_y^2) - o_x u_x u_z + f u_z^2}
-                      }{u_x^2 + u_y^2}.
+                      }{u_x^2 + u_y^2},
+
+        of which the intercept is the root with the smaller :math:`|d|`, the
+        crossing nearest the ray's current position.
 
         If the line is parallel to the :math:`z` axis, then the above equation
         is singular and we need to solve the corresponding linear equation to find
@@ -139,13 +142,35 @@ class ParabolicSag(
         uy = u.y  # noqa: F841
         uz = u.z  # noqa: F841
 
+        # The two halves of the quadratic formula.  `midpoint` lies halfway
+        # between the roots and `halfwidth` is half the distance between them,
+        # so the roots are `midpoint - halfwidth` and `midpoint + halfwidth`.
+        midpoint = "(-ox * ux - oy * uy + 2 * f * uz)"
+        halfwidth = (
+            "sqrt("
+            "   -(oy * ux)**2 - (ox * uy)**2 + 2 * oy * uy * (ox * ux - 2 * f * uz)"
+            "   + 4 * f * (oz * (ux**2 + uy**2) - ox * ux * uz + f * uz**2)"
+            ")"
+        )
+        near = f"{midpoint} - {halfwidth}"
+        far = f"{midpoint} + {halfwidth}"
+
+        # Take the root nearest the ray's current position, as
+        # `AbstractConicSag.intercept` does for every other conic.  Selecting
+        # the root by `sign(f * uz)` instead returns the far crossing for a ray
+        # that starts on the surface, which moves it to the opposite side of
+        # the paraboloid; `optika.systems.SequentialSystem` does exactly that
+        # when it propagates the solved stop rays back through the surface they
+        # were launched from.
+        #
+        # Both roots are built into one `numexpr` expression on purpose:
+        # evaluating the two halves separately and combining them afterwards
+        # measures about 50% slower.
         position = na.numexpr.evaluate(
             "o + u * where("
             "   (ux**2 + uy**2) > 1e-10,"
-            "   (-ox * ux - oy * uy + 2 * f * uz - sign(f * uz) * sqrt("
-            "       -(oy * ux)**2 - (ox * uy)**2 + 2 * oy * uy * (ox * ux - 2 * f * uz)"
-            "       + 4 * f * (oz * (ux**2 + uy**2) - ox * ux * uz + f * uz**2)"
-            "   )) / (ux**2 + uy**2),"
+            f"   where(abs({near}) <= abs({far}), {near}, {far})"
+            "   / (ux**2 + uy**2),"
             "   (ox**2 + oy**2 - 4 * f * oz) / (4 * f * uz),"
             ")"
         )

--- a/optika/sags/_tests/_parabolic_test.py
+++ b/optika/sags/_tests/_parabolic_test.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import astropy.units as u
 import named_arrays as na
 import optika
 from ..._tests import test_mixins
@@ -35,3 +36,92 @@ class TestParabolicSag(
         result_expected = super(type(a), a).normal(position)
 
         assert np.allclose(result, result_expected)
+
+
+@pytest.mark.parametrize("focal_length", [-1 * u.mm, 1 * u.mm, -1000 * u.mm])
+@pytest.mark.parametrize("radius", [10 * u.mm, 76 * u.mm])
+@pytest.mark.parametrize("angle", [-4 * u.deg, 4 * u.deg])
+def test_intercept_of_ray_on_the_surface(
+    focal_length: u.Quantity,
+    radius: u.Quantity,
+    angle: u.Quantity,
+):
+    """
+    A ray which starts on the paraboloid must be intercepted where it already
+    is, not at the surface's other crossing.
+
+    A paraboloid seen at grazing incidence is crossed twice by the same line,
+    and a ray launched from the surface is the degenerate case of that: one
+    root is zero and the other is far away.  Choosing between the roots by the
+    sign of the focal length, rather than by their distance from the ray,
+    moves such a ray to the opposite side of the paraboloid whenever it
+    travels toward the axis on a steep flank.
+    :class:`optika.systems.SequentialSystem` meets exactly that case when it
+    propagates its solved stop rays back through the surface they were
+    launched from, and the resulting entrance pupil is silently wrong rather
+    than obviously so.
+    """
+    sag = optika.sags.ParabolicSag(focal_length=focal_length)
+
+    position = na.Cartesian3dVectorArray(x=radius, y=0 * u.mm, z=0 * u.mm)
+    position = position.replace(z=sag(position))
+
+    direction = na.Cartesian3dVectorArray(
+        x=np.sin(angle),
+        y=0,
+        z=np.cos(angle),
+    )
+
+    rays = optika.rays.RayVectorArray(
+        wavelength=500 * u.nm,
+        position=position,
+        direction=direction,
+    )
+
+    result = sag.intercept(rays)
+
+    assert np.allclose(result.position, position)
+
+
+@pytest.mark.parametrize(
+    argnames="focal_length",
+    argvalues=[-1000 * u.mm, -100 * u.mm, 100 * u.mm, 1000 * u.mm],
+)
+def test_intercept_matches_the_conic_intercept(focal_length: u.Quantity):
+    """
+    A paraboloid is a conic with a conic constant of -1, so the closed-form
+    intercept here must agree with the general conic intercept.
+
+    Every ray in this test strikes the paraboloid, since the two
+    implementations report a miss differently: this one gives not-a-number and
+    :class:`optika.sags.ConicSag` gives infinity.
+    """
+    sag = optika.sags.ParabolicSag(focal_length=focal_length)
+    sag_conic = optika.sags.ConicSag(radius=2 * focal_length, conic=-1)
+
+    radius = na.linspace(10, 100, axis="radius", num=11) * u.mm
+    azimuth = na.linspace(0, 360, axis="azimuth", num=7) * u.deg
+
+    position = na.Cartesian3dVectorArray(
+        x=radius * np.cos(azimuth),
+        y=radius * np.sin(azimuth),
+        z=-500 * u.mm,
+    )
+
+    angle = na.linspace(-4, 4, axis="angle", num=5) * u.deg
+    direction = na.Cartesian3dVectorArray(
+        x=np.sin(angle),
+        y=0,
+        z=np.cos(angle),
+    )
+
+    rays = optika.rays.RayVectorArray(
+        wavelength=500 * u.nm,
+        position=position,
+        direction=direction,
+    )
+
+    result = sag.intercept(rays)
+    result_expected = sag_conic.intercept(rays)
+
+    assert np.allclose(result.position, result_expected.position)


### PR DESCRIPTION
## The bug

`ParabolicSag.intercept` chooses between the two roots of the ray-paraboloid quadratic with `sign(f * u_z)`, a rule that does not depend on where the ray actually is. For a ray that starts **on** the surface and travels toward the axis on a steep flank, it returns the far crossing rather than the ray's own position, relocating the ray to the opposite side of the paraboloid.

```
f = -0.65 mm, radius 76 mm, ray at -3.94 deg to the axis, starting on the surface
  -> intercept moves it 1662.7 mm
```

`optika.systems.SequentialSystem` meets exactly that case whenever the field stop lies downstream of the pupil stop. `_calc_rayfunction_stops` propagates the solved stop rays back through the surface they were launched from (`subsystem = surfaces[index_stop::-1]`), so those rays start on the pupil-stop surface by construction. They get relocated, reflected in the wrong place, and never reverse: their z-direction stays around +0.8 instead of −1.

**The failure is silent.** The solver reports convergence and returns an entrance pupil wrong by orders of magnitude. On a grazing-incidence Wolter telescope with a slit at its focus, the shared pupil box came out as x from −1958 to +1507 mm for a mirror annulus 2 mm wide, the per-field fit fell back, and no ray survived a normalized raytrace at any grid density.

## The fix

Take the root nearest the ray, which is what `AbstractConicSag.intercept` (#167) already does for every other conic. A paraboloid is a conic with conic constant −1, so the two implementations should agree, and now they do to about 1e-12 mm.

After the fix, the same grazing system gives a pupil box of 70.79 to 77.80 mm against an annulus of 75.00 to 77.18, the per-field pupil fit succeeds, and the normalized raytrace reaches the detector.

## Performance

The override exists because it does the whole solve in a single `numexpr` pass, so it is kept and only the root selection changes. Both roots are built into the same expression on purpose. Measured over 1e6 rays:

| | time |
|---|---|
| before | 36 ms |
| after | 41 ms |
| deleting the override, inheriting `AbstractConicSag.intercept` | 124 ms |
| computing the two halves in separate `numexpr` calls | 62 ms |

## Tests

Two new tests in `optika/sags/_tests/_parabolic_test.py`:

- `test_intercept_of_ray_on_the_surface` places a ray on the paraboloid and asserts the intercept leaves it there. Two of its twelve parameterizations fail on `main`.
- `test_intercept_matches_the_conic_intercept` checks agreement with `ConicSag(radius=2f, conic=-1)` over a grid of radii, azimuths, and ray angles.

Full suite on this branch: 18334 passed, 304 skipped, 17 xfailed.

## Note for a separate change

The two implementations report a ray that misses the surface differently: this one gives not-a-number, `ConicSag` gives infinity. The comparison test avoids that by using geometries where every ray strikes the surface. Worth reconciling, but not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc