### PR TITLE
Let the vignetting and distortion plots choose the unit of the field

### DIFF
--- a/optika/distortion/_distortion.py
+++ b/optika/distortion/_distortion.py
@@ -423,6 +423,7 @@ class PolynomialDistortionModel(
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
         vmax: None | na.ArrayLike = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> tuple[matplotlib.figure.Figure, na.ScalarArray]:
         """
@@ -453,6 +454,14 @@ class PolynomialDistortionModel(
         vmax
             The residual value mapped to the highest color.
             If :obj:`None`, defaults to the maximum residual.
+        unit
+            The unit to express the field position in.
+
+            A model is free to describe the scene in whichever unit suits it,
+            and the one that suits the fit is not always the one that reads
+            well on an axis: a field of a tenth of a degree is easier to see
+            in arcseconds. If :obj:`None`, the position is drawn in the unit
+            it is already in.
         kwargs
             Additional keyword arguments passed to
             :func:`named_arrays.plt.pcolormesh`.
@@ -461,6 +470,9 @@ class PolynomialDistortionModel(
         position = scene.position
         wavelength = na.as_named_array(scene.wavelength)
         axis_wavelength = self.axis_wavelength
+
+        if unit is not None:
+            position = position.to(unit)
 
         residual = (self.coordinates_sensor - self.fit.predictions).length
         unit = na.unit(residual)

--- a/optika/distortion/_distortion_test.py
+++ b/optika/distortion/_distortion_test.py
@@ -183,6 +183,29 @@ class TestPolynomialDistortionModel(
 
         plt.close(fig)
 
+    def test_plot_residual_unit(
+        self,
+        a: optika.distortion.PolynomialDistortionModel,
+    ):
+        """The field position is drawn in the unit asked for, labels and all."""
+        fig_deg, ax_deg = a.plot_residual()
+        fig_arcsec, ax_arcsec = a.plot_residual(unit=u.arcsec)
+
+        axs_deg = ax_deg.ndarray.reshape(-1)[0]
+        axs_arcsec = ax_arcsec.ndarray.reshape(-1)[0]
+
+        scale = u.deg.to(u.arcsec)
+        for get in ("get_xlim", "get_ylim"):
+            lim_deg = getattr(axs_deg, get)()
+            lim_arcsec = getattr(axs_arcsec, get)()
+            assert lim_arcsec == pytest.approx(tuple(scale * x for x in lim_deg))
+
+        assert format(u.arcsec, "latex_inline") in axs_arcsec.get_xlabel()
+        assert format(u.deg, "latex_inline") in axs_deg.get_xlabel()
+
+        plt.close(fig_deg)
+        plt.close(fig_arcsec)
+
     def test_plot_residual_ax_invalid(
         self,
         a: optika.distortion.PolynomialDistortionModel,

--- a/optika/radiometry/_vignetting.py
+++ b/optika/radiometry/_vignetting.py
@@ -7,6 +7,7 @@ import matplotlib.colors
 import matplotlib.figure
 import matplotlib.pyplot as plt
 import numpy as np
+import astropy.units as u
 import astropy.visualization
 import named_arrays as na
 import optika
@@ -214,6 +215,7 @@ class PolynomialVignettingModel(
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
         vmax: None | na.ArrayLike = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> tuple[matplotlib.figure.Figure, na.ScalarArray]:
         """
@@ -245,6 +247,14 @@ class PolynomialVignettingModel(
             The residual value mapped to the highest color.
             If :obj:`None`, defaults to the largest residual among the points
             the fit was constrained by.
+        unit
+            The unit to express the field position in.
+
+            A model is free to describe the scene in whichever unit suits it,
+            and the one that suits the fit is not always the one that reads
+            well on an axis: a field of a tenth of a degree is easier to see
+            in arcseconds. If :obj:`None`, the position is drawn in the unit
+            it is already in.
         kwargs
             Additional keyword arguments passed to
             :func:`named_arrays.plt.pcolormesh`.
@@ -262,6 +272,7 @@ class PolynomialVignettingModel(
             cmap=cmap,
             vmin=vmin,
             vmax=vmax,
+            unit=unit,
             **kwargs,
         )
 
@@ -272,6 +283,7 @@ class PolynomialVignettingModel(
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
         vmax: None | na.ArrayLike = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> tuple[matplotlib.figure.Figure, na.ScalarArray]:
         """
@@ -298,6 +310,14 @@ class PolynomialVignettingModel(
         vmax
             The illumination value mapped to the highest color.
             If :obj:`None`, defaults to the maximum illumination.
+        unit
+            The unit to express the field position in.
+
+            A model is free to describe the scene in whichever unit suits it,
+            and the one that suits the fit is not always the one that reads
+            well on an axis: a field of a tenth of a degree is easier to see
+            in arcseconds. If :obj:`None`, the position is drawn in the unit
+            it is already in.
         kwargs
             Additional keyword arguments passed to
             :func:`named_arrays.plt.pcolormesh`.
@@ -310,6 +330,7 @@ class PolynomialVignettingModel(
             cmap=cmap,
             vmin=vmin,
             vmax=vmax,
+            unit=unit,
             **kwargs,
         )
 
@@ -322,6 +343,7 @@ class PolynomialVignettingModel(
         cmap: None | str | matplotlib.colors.Colormap = None,
         vmin: None | na.ArrayLike = None,
         vmax: None | na.ArrayLike = None,
+        unit: None | u.UnitBase = None,
         **kwargs,
     ) -> tuple[matplotlib.figure.Figure, na.ScalarArray]:
         """
@@ -332,6 +354,9 @@ class PolynomialVignettingModel(
         position = scene.position
         wavelength = na.as_named_array(scene.wavelength)
         axis_wavelength = self.axis_wavelength
+
+        if unit is not None:
+            position = position.to(unit)
 
         if vmin is None:
             vmin = 0

--- a/optika/radiometry/_vignetting_test.py
+++ b/optika/radiometry/_vignetting_test.py
@@ -205,6 +205,42 @@ def test_polynomial_vignetting_model_channel():
     assert np.all(np.abs(result - illumination) < 1e-9)
 
 
+@pytest.mark.parametrize(
+    argnames="method",
+    argvalues=["plot", "plot_residual"],
+)
+def test_plot_unit(method: str):
+    """The field position is drawn in the unit asked for, labels and all."""
+    a = optika.radiometry.PolynomialVignettingModel(
+        coordinates_scene=_scene(),
+        illumination=_illumination(),
+        axis_wavelength="wavelength",
+        axis_field=("field_x", "field_y"),
+        degree=1,
+    )
+
+    fig_deg, ax_deg = getattr(a, method)()
+    fig_arcsec, ax_arcsec = getattr(a, method)(unit=u.arcsec)
+
+    axs_deg = ax_deg.ndarray.reshape(-1)[0]
+    axs_arcsec = ax_arcsec.ndarray.reshape(-1)[0]
+
+    # the scene is described in degrees, so drawing it in arcseconds has to
+    # stretch both axes by exactly the ratio of the two units
+    scale = u.deg.to(u.arcsec)
+    for get in ("get_xlim", "get_ylim"):
+        lim_deg = getattr(axs_deg, get)()
+        lim_arcsec = getattr(axs_arcsec, get)()
+        assert lim_arcsec == pytest.approx(tuple(scale * x for x in lim_deg))
+
+    # and to say so on the axis
+    assert format(u.arcsec, "latex_inline") in axs_arcsec.get_xlabel()
+    assert format(u.deg, "latex_inline") in axs_deg.get_xlabel()
+
+    plt.close(fig_deg)
+    plt.close(fig_arcsec)
+
+
 def test_plot_residual_where():
     """
     The residual is undefined at the calibration points the fit was not


### PR DESCRIPTION
`PolynomialVignettingModel.plot()`, `.plot_residual()`, and `PolynomialDistortionModel.plot_residual()` draw the field position in whatever unit the scene happens to be described in, and the unit that suits the fit is not always the one that reads well on an axis. A field of a tenth of a degree spends its ticks on leading zeros — `-0.05°`, `0°`, `0.05°`. The same field in arcseconds is numbered `-250`, `0`, `250`.

All three now take the `unit` parameter the rest of the library's plotting already takes: `SequentialSystem.plot`, both of `LinearSystem`'s, `Surface.plot`, and the apertures. The position is converted before it is drawn, and the axis label follows without being told, since it already reads the unit off the position it was handed. Passing nothing draws it in the unit it is already in, as before.

It names the unit of the **field position**, which is the pair of axes both plots share. The distortion residual's own unit, on its colorbar, is a length on the sensor and is left alone.

## Why not do this in the caller

You can get the same picture by rebuilding the model with the scene converted, `model.replace(coordinates_scene=...)`. It works — I measured the residual as unchanged to 6 × 10⁻¹⁵ — but `fit` is a `cached_property`, so replacing the coordinates silently refits the polynomial. Changing a display unit and refitting a model should not be the same operation.

## Tests

`test_plot_unit` on both vignetting plotters and `test_plot_residual_unit` on the distortion one draw the same model twice, once in its own units and once in arcseconds, then check that both axes stretched by exactly the ratio of the two units and that each figure's label names the unit it was drawn in. Comparing the two renders rather than an absolute limit is deliberate: `pcolormesh` extends an axis half a cell past the outermost sample, so the limit is not the field's extent and hard-coding it would be asserting the wrong thing.

654 pass across `optika/radiometry`, `optika/distortion`, and `optika/systems`.

Found while porting the vignetting subsection of the ESIS instrument paper, whose field is ±347″.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYjDL98znSud1yFh9chnkP