### PR TITLE
Measure every result in the frame the system carries with it

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,17 @@ Jupyter notebook examples on how to use :mod:`optika`.
     tutorials/prime_focus
 
 
+Topic Guides
+============
+
+Longer descriptions of how parts of :mod:`optika` work.
+
+.. toctree::
+    :maxdepth: 1
+
+    stop_finding
+
+
 API Reference
 =============
 

--- a/docs/stop_finding.rst
+++ b/docs/stop_finding.rst
@@ -1,0 +1,366 @@
+Stop Finding
+============
+
+One of the design goals of :mod:`optika` is to automatically compute the
+field of view and entrance pupil of an optical system (see
+:attr:`~optika.systems.AbstractSequentialSystem.field_min`,
+:attr:`~optika.systems.AbstractSequentialSystem.field_max`,
+:attr:`~optika.systems.AbstractSequentialSystem.pupil_min`, and
+:attr:`~optika.systems.AbstractSequentialSystem.pupil_max`).
+Unlike Zemax, the user never has to specify the extent of the field or pupil.
+This page describes the strategy :mod:`optika` uses to discover that extent and
+to sample the field and pupil for imaging, since the strategy spans several
+methods and the reasoning behind it is easy to lose.
+
+
+Overview
+--------
+
+The trajectory of a ray through a sequential system is fixed by two surfaces:
+
+* the **field stop**, which limits the region of the object that is imaged, and
+* the **pupil stop** (or aperture stop), which limits the bundle of rays
+  accepted from each point of the object.
+
+A surface is marked as a stop by setting ``is_field_stop=True`` or
+``is_pupil_stop=True`` on it. Every ray that survives the system passes inside
+both stops, so a ray that grazes the *border* of one stop while passing through
+a chosen point of the other traces out the boundary of the accepted light. This
+is what :attr:`~optika.systems.AbstractSequentialSystem.rayfunction_stops`
+returns: a :class:`~optika.rays.RayFunctionArray`, defined on the first surface
+of the system, whose rays are constructed to strike prescribed points on both
+the field stop and the pupil stop. The field of view, the entrance pupil, and
+the sampling of rays used for image simulation are all derived from it.
+
+The difficulty is that a ray is launched from the *first* surface, but the
+constraints live on the *stop* surfaces further downstream. There is no
+closed-form expression for the launch coordinate that lands a ray on a given
+point of a given stop, so the launch coordinate is found by root-finding.
+
+
+Two principles
+--------------
+
+Everything below follows from two physical requirements. They are worth stating
+up front because they dictate *where* each coordinate is measured, and getting
+the measurement plane wrong produces answers that look plausible but are subtly
+biased.
+
+**The field is anchored on the object plane.**
+    A point-spread function is the image of a single point of the object. For
+    the simulated PSF to be correct, every ray in a given field bundle must
+    share one object direction (for a distant object) or one object position
+    (for a nearby object). If the field were instead anchored on an internal
+    surface, rays with the same field label but different pupil labels would
+    correspond to slightly different object points, smearing the PSF. So the
+    field coordinate is always resolved on the object plane.
+
+**The pupil is measured at the entrance pupil.**
+    The entrance pupil is the image of the pupil stop in object space, i.e. the
+    plane on which the incoming wavefront is uniform for a uniform distant
+    source. Measuring and sampling the pupil *there*, rather than on the
+    angular object plane or on the pupil stop itself, matters for two reasons:
+
+    * **Robustness.** For a system with a tiny entrance aperture (a feed optic
+      much smaller than the beam, as in FURST), the entrance-pupil extent is
+      essentially independent of field, so rays aimed through it always land on
+      the aperture. Measured instead as an angle on the object plane, the same
+      extent swings with field and a single global box makes most field angles
+      miss the aperture.
+
+    * **Radiometry.** Vignetting is the fraction of the accepted bundle that
+      survives to the detector, an area integral over the pupil. Sampling
+      uniformly on the entrance pupil is equal-area sampling in the plane where
+      the wavefront is uniform, so the vignetting fraction is an unweighted mean
+      of the surviving samples. Sampling uniformly on the pupil stop instead
+      would, for a system with pupil distortion (such as the grating in ESIS,
+      which is the pupil stop), place unequal areas of the entrance pupil under
+      each sample and bias the result.
+
+The consequence is that the field is resolved as an object-space coordinate and
+the pupil as an entrance-pupil coordinate, and the machinery below exists to
+connect those object-space coordinates to the physical stop surfaces.
+
+
+Input coordinates
+-----------------
+
+A stop ray is labelled by three input coordinates, gathered together in an
+:class:`~optika.vectors.ObjectVectorArray`:
+
+``wavelength``
+    The vacuum wavelength of the ray. It is carried through the solve
+    unchanged; it only matters because dispersive surfaces (gratings) bend
+    different wavelengths differently.
+
+``field``
+    A two-dimensional coordinate locating the ray on the field stop.
+
+``pupil``
+    A two-dimensional coordinate locating the ray on the pupil stop.
+
+Both ``field`` and ``pupil`` may be given in either **normalized** or
+**physical** units, and the units alone tell :mod:`optika` how to interpret
+them:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 25 25 50
+
+    * - Units
+      - Meaning
+      - Interpretation
+    * - dimensionless
+      - normalized
+      - A value in :math:`[-1, 1]`, denormalized against the bounding box of
+        the relevant stop's aperture.
+    * - length (e.g. ``mm``)
+      - physical position
+      - A position on the relevant surface.
+    * - angle (e.g. ``deg``)
+      - physical direction
+      - A direction, converted to direction cosines with
+        :func:`~optika.direction`.
+
+This convention (dimensionless means normalized, length means position, angle
+means direction) is used consistently throughout the stop-finding code; see
+``_coordinates_are_normalized`` and
+:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity`.
+
+
+The two-point ray solve
+-----------------------
+
+The core primitive is the private method ``_solve_rays``. Given a
+``subsystem`` (a contiguous slice of the system's surfaces), a wavelength, a
+grid ``grid_first`` on the first surface, and a grid ``grid_last`` on the last
+surface, it finds the launch ray that connects them. Both grids are given in
+*physical* units; denormalizing a normalized stop coordinate against its
+aperture is the caller's job, so at this boundary a dimensionless grid is an
+unambiguous direction cosine rather than a normalized coordinate.
+
+A ray leaving the first surface has two degrees of freedom that are *not*
+pinned by ``grid_first``. If ``grid_first`` is a **position**, the free degrees
+of freedom are the launch **direction**; if ``grid_first`` is a **direction**,
+they are the launch **position**. ``_solve_rays`` reads which case applies from
+the units of ``grid_first`` (length means position, angle or dimensionless
+direction cosine means direction), builds a
+:class:`~optika.rays.RayVectorArray` with the fixed coordinate filled in, and
+solves for the free coordinate so that the ray lands on ``grid_last`` at the
+last surface. The residual whose root is sought is the miss distance at the
+last surface,
+
+.. math::
+
+    \vec{r}(\vec{a}) = \vec{g}_\text{trial}(\vec{a}) - \vec{g}_\text{last},
+
+where :math:`\vec{a}` is the trial value of the free coordinate and
+:math:`\vec{g}_\text{trial}` is where the resulting ray actually crosses the
+target coordinate of the last surface (its position if ``grid_last`` is a
+position, its direction if ``grid_last`` is a direction). This residual is
+evaluated by ``_ray_error`` and driven to zero with
+:func:`named_arrays.optimize.root_newton`.
+
+Because ``grid_last`` may itself be either a position or a direction, the same
+routine works in either direction along the system. In particular, running it
+with the subsystem reversed and an angular ``grid_last`` back-traces rays to a
+target *direction* on an object at infinity, which is how the field extent on
+the object plane is recovered.
+
+Two details make the solve robust across systems of wildly different physical
+scale:
+
+* **Seeding.** The initial guess aims each ray from the first surface toward a
+  sensible target: directly at its point on the last surface when no surface
+  with optical power lies in between (the guess is then nearly exact), and
+  otherwise at the center of the first powered surface (a mirror, a curved sag,
+  or a ruled surface, found by ``_anchor_surface``). This keeps the guess
+  inside the basin of convergence even for strongly off-axis feed or fold
+  mirrors.
+
+* **Scaling.** Both the convergence tolerance and the finite-difference step
+  used to estimate the Jacobian are scaled by the size of the target aperture,
+  so that a millimeter-scale spectrograph and a meter-scale telescope are
+  solved to the same *relative* precision. The default absolute step of
+  :func:`named_arrays.jacobian` is otherwise below the floating-point noise
+  floor of the raytrace and yields a Jacobian made of noise.
+
+``_solve_rays`` returns the launch rays *at the first surface* (in global
+coordinates), with both the given and the solved coordinate filled in, so that
+propagating them through the subsystem reproduces ``grid_last``.
+
+
+The strategy
+------------
+
+The two principles rule out computing a single global field box and a single
+global pupil box, because the entrance-pupil extent depends on field. Instead
+the field of view and the per-field entrance pupil are calibrated in stages,
+and the expensive root-finding is confined to a coarse grid.
+
+**1. Field extent on the object plane.**
+    A small number of rays connecting the field-stop border to the pupil-stop
+    border are traced back to the object plane, and their extent gives the
+    field of view. This is the object-plane field domain that every later stage
+    samples within.
+
+**2. Per-field entrance-pupil extent.**
+    The object surface is treated as the field stop, and a *coarse* grid of
+    field directions, sampled evenly across the field of view from stage 1, is
+    connected to every point on the *wire* (border) of the pupil stop with
+    ``_solve_rays``. Only the wire is needed: it is the boundary of the pupil
+    stop, so its image on the entrance pupil is the boundary of the entrance
+    pupil, and the minimum and maximum of those positions give a per-field
+    entrance-pupil bounding box. This is the stage that captures the
+    field dependence of the pupil (the pupil distortion), and it is the only
+    stage that pays for dense root-finding, kept affordable by using a coarse
+    field grid and only the one-dimensional pupil-stop wire.
+
+**3. Interpolation.**
+    The per-field bounding box from stage 2 is a smooth function of field (it is
+    the pupil distortion), so it is fit on the coarse field grid and
+    interpolated onto the dense field grid, in the same spirit as
+    :class:`~optika.distortion.PolynomialDistortionModel` and the vignetting
+    models. The coarse grid must be fine enough to resolve the distortion, not
+    the scene.
+
+**4. Dense forward trace.**
+    For image simulation, each dense ray is fully specified in object space: its
+    direction is an object-plane field angle, and its position is a normalized
+    pupil coordinate mapped onto the interpolated per-field entrance-pupil box.
+    Both coordinates are known without any root-finding, so the dense pass is a
+    pure *forward* trace through the system. This is what keeps a
+    :math:`1000 \times 1000` field affordable: the Newton solves live entirely
+    in the coarse calibration of stage 2, never in the dense grid.
+
+Because a uniform grid on the entrance-pupil box is equal-area in the plane
+where the wavefront is uniform, the vignetted fraction of that grid (with the
+``where`` keyword marking the surviving rays) is the vignetting directly, with
+no Jacobian weight. The axis-aligned bounding box slightly over-covers a
+rotated or astigmatic entrance pupil, but the excess samples fall outside the
+aperture and are removed by vignetting, so the result is correct if marginally
+less sample-efficient.
+
+
+The object as the field stop
+----------------------------
+
+Stage 2 relies on being able to mark the **object surface itself** as the field
+stop, with an angular (dimensionless, sine-of-half-angle) aperture. The
+``field`` coordinate is then a direction on the object plane rather than a
+position on an internal surface, which is exactly the object-plane anchoring the
+first principle requires. It is also the only workable option in two common
+cases where an internal field stop has no solution:
+
+* **Spectrographs**, where the field stop is the detector. A single wavelength
+  illuminates only part of the detector, so connecting the *border* of the
+  detector to the pupil stop has no solution at that wavelength.
+
+* **Systems with a tiny entrance aperture**, where a single global pupil box,
+  back-projected to the object, misses the feed optic for most field angles.
+
+When ``_solve_rays`` cannot connect an internal field stop at a single
+wavelength, the raised error points the user toward this option. Whether the
+object is treated as being at infinity is inferred from the units of its
+aperture: a length aperture is a finite object, a dimensionless aperture is an
+object at infinity (see
+:attr:`~optika.systems.AbstractSequentialSystem.object_is_at_infinity`).
+
+
+Field of view and entrance pupil
+--------------------------------
+
+The field of view and entrance pupil are read off from the stop rayfunction by
+reducing over *both* the field and pupil axes:
+
+* :attr:`~optika.systems.AbstractSequentialSystem.field_min` /
+  :attr:`~optika.systems.AbstractSequentialSystem.field_max` give the corners
+  of the field of view, expressed as angles (via :func:`~optika.angles`) when
+  the object is at infinity and as positions otherwise.
+
+* :attr:`~optika.systems.AbstractSequentialSystem.pupil_min` /
+  :attr:`~optika.systems.AbstractSequentialSystem.pupil_max` give the corners
+  of the entrance pupil, expressed as positions when the object is at infinity
+  and as angles otherwise.
+
+The two swap roles with object distance because field and pupil are conjugate:
+for a distant object the field is naturally angular and the pupil is a physical
+aperture, while for a nearby object the field is a physical extent and the
+pupil subtends an angle.
+
+
+The entrance pupil of each field point
+--------------------------------------
+
+The stop rayfunction gives one entrance pupil for the whole field: the box
+which every field point's pupil fits inside. That box is larger than any
+individual field point's pupil whenever the pupil walks across the field,
+which it does whenever the pupil stop is far from the entrance pupil. Rays
+drawn uniformly in it are then mostly outside the pupil of the field point
+they belong to, and are thrown away at the stop.
+
+:meth:`~optika.systems.AbstractSequentialSystem._calc_pupil_fit` calibrates the
+pupil per field point instead. It fits a quadratic in the field to the corners
+of the pupil, using the samples already present along the edge of the field
+stop plus one traced at the center of the field, and
+:meth:`~optika.systems.AbstractSequentialSystem._denormalize_grid` evaluates
+that fit at each field point being traced.
+
+Three things keep it honest:
+
+* The fitted box is clipped to the box shared by every field point, so a fit
+  which extrapolates cannot send rays outside the pupil the stops actually
+  admit.
+
+* Where the clipped box inverts, the shared box is used instead.
+
+* If the center of the field cannot be traced, or the fit is singular, the
+  whole calibration returns :obj:`None` and the shared box is used. This is
+  never worse than not having the fit at all.
+
+The fit is in the field alone; the wavelength rides along as a broadcast axis,
+since the fit is only ever evaluated at the wavelengths it was made at. It is
+cached on the system, along with the stop rays it is built from, because both
+depend on nothing but the wavelength.
+
+
+Conventions and assumptions
+---------------------------
+
+A few conventions are load-bearing and worth stating explicitly:
+
+* **Dimensionless means normalized at the system input, and a direction cosine
+  inside the solve.** A ``field`` or ``pupil`` grid supplied to the system is
+  interpreted as normalized when it is dimensionless (see the table above).
+  Denormalization happens before ``_solve_rays`` is called, so once inside the
+  solve a dimensionless grid is unambiguously a physical direction cosine.
+
+* **The pupil is measured in an object-space plane.** The entrance-pupil extent
+  and the sampling grid live on the entrance pupil, not on the pupil stop.
+  Measuring on the pupil stop would reintroduce the distortion bias the second
+  principle exists to avoid.
+
+* **Every grid and every set of rays belongs to a stated frame, and mixing two
+  of them is the most common way to get a wrong answer here.** Three
+  conventions are in play, and each is load-bearing:
+
+  * A grid produced by denormalizing an aperture is in **that surface's own
+    frame**, since an aperture and a sag are only defined there.
+
+  * ``_solve_rays`` takes its launch grid in the launch surface's frame and
+    returns the solved rays in the **global** frame, converting once at each
+    end.  Its ``aim`` argument is global.
+
+  * ``_calc_rayfunction_stops`` and ``_calc_rayfunction_pupil`` return their
+    rays in the **object surface's** frame, because that is the frame in which
+    ``_calc_rayfunction_input`` reads the field and pupil of the input grid.
+    The entrance pupil is fit from samples taken from both, so they have to
+    agree; a rotated object otherwise trains the fit on a center sample taken
+    at a different field point than its edge samples.
+
+  Nothing in the type system enforces any of this, so a function which takes
+  or returns rays should say which frame they are in.
+
+* **Angles are direction cosines.** :func:`~optika.direction` and
+  :func:`~optika.angles` convert between a pair of azimuth/elevation angles and
+  a three-dimensional direction cosine, and are inverses of each other.

--- a/docs/stop_finding.rst
+++ b/docs/stop_finding.rst
@@ -358,8 +358,23 @@ A few conventions are load-bearing and worth stating explicitly:
     agree; a rotated object otherwise trains the fit on a center sample taken
     at a different field point than its edge samples.
 
+  * :meth:`~optika.systems.AbstractSequentialSystem.rayfunction` returns its
+    rays in the **sensor's** frame, which is the sensor's own transformation
+    with the system's
+    :attr:`~optika.systems.SequentialSystem.transformation` composed on top,
+    since that is where ``surfaces_all`` places the sensor.  Its counterpart
+    :meth:`~optika.systems.AbstractSequentialSystem.raytrace` returns global
+    rays instead.
+
   Nothing in the type system enforces any of this, so a function which takes
-  or returns rays should say which frame they are in.
+  or returns rays should say which frame they are in.  What does enforce it is
+  ``test_rayfunction_is_invariant_under_a_rigid_motion``, which moves every
+  surface of a system together.  That describes the same instrument in a
+  different frame, so nothing the system reports may change; a quantity
+  measured in the global frame by mistake moves with the motion and fails.
+  Building a system at an angle on purpose does not test this, because tilting
+  one surface changes the instrument and can stop any light reaching the
+  sensor, which no amount of broken frame handling would then make worse.
 
 * **Angles are direction cosines.** :func:`~optika.direction` and
   :func:`~optika.angles` convert between a pair of azimuth/elevation angles and

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -658,10 +658,15 @@ class AbstractSequentialSystem(
         obj = subsystem[~0]
         rays = result.outputs
         if obj.transformation is not None:
+            # express the stop rays in the local coordinates of the object
+            # surface, since that is the frame in which the field and pupil
+            # coordinates of the input grid are interpreted by
+            # `_calc_rayfunction_input`
             rays = obj.transformation.inverse(rays)
 
         where = rays.direction @ obj.sag.normal(rays.position) > 0
-        result.outputs.direction[where] = -result.outputs.direction[where]
+        rays.direction[where] = -rays.direction[where]
+        result.outputs = rays
 
         # If the first stop is the object surface, the solved variable is the
         # position and the direction retains only the field-stop axis, so

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1600,8 +1600,17 @@ class AbstractSequentialSystem(
         rayfunction = raytrace[{axis: ~0}]
         rays = rayfunction.outputs
 
-        if self.sensor.transformation is not None:
-            rays = self.sensor.transformation.inverse(rays)
+        # The sensor sits where `surfaces_all` puts it, which is its own
+        # transformation with `transformation` composed on top, so both are
+        # needed to express these rays in the frame of the sensor. Using only
+        # the sensor's own transformation leaves the rays of a system with a
+        # `transformation` in neither the sensor's frame nor the global one.
+        transformation = na.transformations.compose(
+            self.transformation,
+            self.sensor.transformation,
+        )
+        if transformation is not None:
+            rays = transformation.inverse(rays)
 
         rayfunction.outputs = rays
 

--- a/optika/systems/_sequential.py
+++ b/optika/systems/_sequential.py
@@ -1072,6 +1072,11 @@ class AbstractSequentialSystem(
         aim = None
         if rayfunction_stops is not None and self.object_is_at_infinity:
             aim = rayfunction_stops.outputs.position.mean(self.axis_stops)
+            # the stop rays are expressed in the object's local coordinates,
+            # while `_solve_rays` aims in global ones
+            obj = subsystem[0]
+            if obj.transformation is not None:
+                aim = obj.transformation(aim)
 
         rays = self._solve_rays(
             subsystem=subsystem,
@@ -1092,6 +1097,15 @@ class AbstractSequentialSystem(
             rays=rays,
             efficiency=False,
         )
+
+        # `_calc_pupil_fit` fits these against samples taken from the stop
+        # rays, which `_calc_rayfunction_stops` expresses in the object's own
+        # coordinates.  Express these the same way, so that the two are
+        # measured in one frame; otherwise a rotated object trains the fit on
+        # a center sample taken at a different field point than the edges.
+        obj = subsystem[0]
+        if obj.transformation is not None:
+            rays = obj.transformation.inverse(rays)
 
         # The solved component carries the pupil-stop axis and the fixed one
         # only the field axes, so broadcast them against each other to keep

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -716,3 +716,80 @@ class TestSequentialSystemGrazingSpectrograph(
         result = a.field_max
         assert np.abs(result.x - _radius_field_grazing) < 1e-6 * u.deg
         assert np.abs(result.y - _radius_field_grazing) < 1e-6 * u.deg
+
+
+# the field stop is decentered so that a mirrored field frame is observable:
+# rays aimed using global-frame field bounds miss the aperture entirely
+_radius_field_rotated = 2 * u.mm
+_decenter_field_rotated = 3 * u.mm
+
+_system_rotated_object = optika.systems.SequentialSystem(
+    object=optika.surfaces.Surface(
+        name="source",
+        aperture=optika.apertures.CircularAperture(
+            radius=_radius_field_rotated,
+            transformation=na.transformations.Cartesian3dTranslation(
+                x=_decenter_field_rotated,
+            ),
+        ),
+        is_field_stop=True,
+        transformation=na.transformations.Cartesian3dRotationY(180 * u.deg),
+    ),
+    surfaces=[
+        optika.surfaces.Surface(
+            name="mirror",
+            sag=optika.sags.SphericalSag(radius=240 * u.mm),
+            material=optika.materials.Mirror(),
+            aperture=optika.apertures.CircularAperture(radius=15 * u.mm),
+            is_pupil_stop=True,
+            transformation=na.transformations.Cartesian3dTranslation(
+                z=-200 * u.mm,
+            ),
+        ),
+    ],
+    sensor=optika.sensors.ImagingSensor(
+        name="sensor",
+        width_pixel=150 * u.um,
+        axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
+        timedelta_exposure=1 * u.s,
+        num_pixel=na.Cartesian2dVectorArray(128, 128),
+        transformation=na.transformations.Cartesian3dTranslation(
+            z=100 * u.mm,
+        ),
+    ),
+    grid_input=_grid_input,
+)
+
+
+@pytest.mark.parametrize(argnames="a", argvalues=[_system_rotated_object])
+class TestSequentialSystemRotatedObject(
+    AbstractTestAbstractSequentialSystem,
+):
+    """
+    A finite-conjugate relay whose object surface is rotated 180 degrees
+    about :math:`y`, so its local coordinate frame differs from the global
+    frame. This guards the object-local frame handling of the stop
+    root-finding problem: the solved stop rays must be expressed in the
+    object surface's local coordinates before their direction is flipped,
+    since that is the frame in which the field and pupil coordinates of the
+    input grid are interpreted.
+    """
+
+    def test_field_bounds_match_decentered_aperture(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        x_min = _decenter_field_rotated - _radius_field_rotated
+        x_max = _decenter_field_rotated + _radius_field_rotated
+        assert np.abs(a.field_min.x - x_min) < 1 * u.um
+        assert np.abs(a.field_max.x - x_max) < 1 * u.um
+
+    def test_rays_reach_the_sensor(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        # the square field/pupil grids overfill the circular apertures, so
+        # the unvignetted fraction is well below 1 even for a healthy trace;
+        # with a mirrored object frame it is exactly 0
+        unvignetted = a.rayfunction_default.outputs.unvignetted
+        assert unvignetted.mean().ndarray > 0.25

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -1164,7 +1164,11 @@ def test_pupil_of_each_field_point_is_measured_on_a_translated_object():
     field = a.field_boundary.mean(a.axis_stops)
     rays = a._calc_rayfunction_pupil(wavelength, field, rayfunction_stops=stops)
 
-    assert np.allclose(rays.outputs.position.z, shift)
+    # these come back in the object's own coordinates, as the stop rays do, so
+    # carry them into the world's to say where the object actually is
+    position = a.object.transformation(rays.outputs.position)
+
+    assert np.allclose(position.z, shift)
 
 
 def test_solve_rays_launches_from_a_translated_surface():

--- a/optika/systems/_sequential_test.py
+++ b/optika/systems/_sequential_test.py
@@ -10,6 +10,80 @@ import optika
 from .._tests import test_mixins
 from ._systems_test import AbstractTestAbstractSystem
 
+_motion_rigid = na.transformations.compose(
+    na.transformations.Cartesian3dTranslation(
+        x=7 * u.mm,
+        y=-13 * u.mm,
+        z=29 * u.mm,
+    ),
+    na.transformations.compose(
+        na.transformations.Cartesian3dRotationZ(23 * u.deg),
+        na.transformations.Cartesian3dRotationY(17 * u.deg),
+    ),
+)
+"""
+A rigid motion used to describe a system in a different frame.
+
+The angles and distances are deliberately unrounded, so that a frame error
+cannot hide behind a symmetry of the system it is applied to, and moderate,
+so that no system is carried near the pole of the chart the launch solve
+parametrizes a ray direction on.
+"""
+
+
+def _moved_rigidly(
+    system: optika.systems.AbstractSequentialSystem,
+    motion: na.transformations.AbstractTransformation,
+) -> optika.systems.AbstractSequentialSystem:
+    """
+    Describe `system` in a frame moved by `motion`.
+
+    Every surface moves together, so this is a relabeling of the same
+    instrument rather than a different instrument, and every result of the
+    system must survive it unchanged.
+    :attr:`~optika.systems.AbstractSequentialSystem.transformation` already
+    carries onto every surface except the object, so moving the object is all
+    that is left to do.
+    """
+    obj = system.object
+    if obj is not None:
+        obj = dataclasses.replace(
+            obj,
+            transformation=na.transformations.compose(motion, obj.transformation),
+        )
+    return dataclasses.replace(
+        system,
+        object=obj,
+        transformation=na.transformations.compose(motion, system.transformation),
+    )
+
+
+_grid_field_rigid = na.Cartesian2dVectorLinearSpace(
+    start=-0.9,
+    stop=0.9,
+    axis=na.Cartesian2dVectorArray("_rigid_field_x", "_rigid_field_y"),
+    num=4,
+)
+"""
+The normalized field grid the rigid-motion test traces.
+
+It stops short of the edge of the field so that no ray lands exactly on the
+boundary of an aperture, where the roundoff a rigid motion introduces would
+decide which side of it the ray falls on.
+"""
+
+_grid_pupil_rigid = dataclasses.replace(
+    _grid_field_rigid,
+    axis=na.Cartesian2dVectorArray("_rigid_pupil_x", "_rigid_pupil_y"),
+)
+"""
+The normalized pupil grid the rigid-motion test traces.
+
+The same grid as :obj:`_grid_field_rigid` on its own pair of axes, so that the
+two sweep a four-dimensional grid instead of being broadcast against each
+other.
+"""
+
 
 class AbstractTestAbstractSequentialSystem(
     test_mixins.AbstractTestDxfWritable,
@@ -226,6 +300,49 @@ class AbstractTestAbstractSequentialSystem(
         assert isinstance(raytrace.outputs, optika.rays.RayVectorArray)
         if accumulate:
             assert a.axis_surface in raytrace.shape
+
+    def test_rayfunction_is_invariant_under_a_rigid_motion(
+        self,
+        a: optika.systems.AbstractSequentialSystem,
+    ):
+        """
+        Moving every surface of a system together describes the same
+        instrument in a different frame, so it must leave every result of that
+        system alone.
+
+        Each result is measured in a frame the system carries with it: the
+        field and the pupil in the frame of the object, and the rays in the
+        frame of the sensor. Any of them measured in the global frame instead
+        moves with the motion, and any solve anchored to the global frame
+        finds a different answer, so this exercises every frame the system
+        works in at once. It is an invariance rather than a system built at an
+        angle on purpose, since tilting one surface of a system changes the
+        instrument and can quietly stop any light reaching the sensor, which
+        no amount of broken frame handling would then make worse.
+        """
+        b = _moved_rigidly(a, _motion_rigid)
+
+        kwargs = dict(
+            field=_grid_field_rigid,
+            pupil=_grid_pupil_rigid,
+        )
+        expected = a.rayfunction(**kwargs)
+        result = b.rayfunction(**kwargs)
+
+        # the field and the pupil are denormalized against the stops, which
+        # the system solves for in the frame of its object surface, and the
+        # rays are measured in the frame of the sensor
+        for r, e in [
+            (result.inputs.field, expected.inputs.field),
+            (result.inputs.pupil, expected.inputs.pupil),
+            (result.outputs.position, expected.outputs.position),
+        ]:
+            error = (r - e).length.max()
+            assert error < 1e-6 * e.length.max()
+
+        # no ray sits on the edge of an aperture, so the motion cannot move
+        # one across it and every ray must be vignetted exactly as before
+        assert np.all(result.outputs.unvignetted == expected.outputs.unvignetted)
 
     @pytest.mark.parametrize(
         argnames="wavelength,field,pupil",


### PR DESCRIPTION
## The two places this branch still assumed global

**`_calc_pupil_fit` was fitting across two frames.** It fits the entrance pupil to samples from two sources: the edges come from the stop rays, and one interior sample is traced by `_calc_rayfunction_pupil`. After #198 those are no longer in the same frame. Measured on the Newtonian fixture with the object rotated one degree, asking for a field of `-0.002 deg` returned rays at `-1.002 deg`, so the fit was trained on a centre sample taken at a different field point than its edges. Only the `bound()` clamp kept that from doing visible damage.

**`aim` became object-local.** `_solve_rays` documents it as global, and the expression that builds it from the stop rays is now local. Carried back.

After both, the requested and returned field agree exactly.

## A third: `rayfunction` was not in the sensor's frame

Found by the new test below, not by inspection.

`rayfunction` un-transformed its result by the sensor's *own* transformation and not by the system's, but `surfaces_all` places the sensor with both composed. A system with a `transformation` therefore reported its rays in neither the sensor's frame nor the global one.

ESIS feels this. Every one of the 5489 unvignetted rays of `esis.flights.f1.optics.design_single` landed **outside the sensor's own aperture**, `|y|` reaching 52 mm against a 7.8 mm half width, because the rays kept that channel's roll. All 5489 are inside it now. The multi-channel `design` is unaffected.

## Testing the frame conventions instead of trusting them

Every fixture in `_sequential_test.py` placed its surfaces with translations alone. That is exactly the invariance which hid all of these: a quantity measured in the global frame by mistake is indistinguishable from one measured in the object's frame until something is rotated.

The obvious repair, a fixture built at an angle, does not work. Rotating one surface changes the *instrument* rather than the description of it, and at any useful angle it stops light reaching the sensor, so the test passes on broken code for the wrong reason. Measured on `_system_newtonian`, rotating the object by one degree leaves zero surviving rays whether the frame handling is right or wrong.

`test_rayfunction_is_invariant_under_a_rigid_motion` moves every surface together instead. That describes the same instrument in a different frame, so the field, the pupil, the ray positions and the vignetted set must all come back unchanged, and each of them is measured in a frame the system carries with it. It runs against all nine systems in the module and adds about 13 s.

The traced grid stops short of the edge of the field so no ray sits on the boundary of an aperture, where the roundoff a rigid motion introduces would decide which side of it the ray falls on. With that, the vignetted set matches exactly rather than to within a tolerance.

**It discriminates.** Reverting each frame fix on this branch in turn:

| fix reverted | new test |
| --- | --- |
| launch-surface frame (`_ray_error`) | 9 of 9 fail |
| stop rays in the object frame (#198) | 9 of 9 fail |
| pupil fit in the object frame | 8 of 9 fail |
| sensor frame (this PR) | 9 of 9 fail |

On the branch as it stands the relative error is at worst 1.4e-9, and no ray changes its vignetting.

## Test change

`test_pupil_of_each_field_point_is_measured_on_a_translated_object` asserted the returned rays sit at the object's *global* depth. That encoded the old convention rather than the property it is checking, which is that the rays lie on the object surface. It now transforms to the world and asserts the same thing there, so it holds under either convention.

## Docs

Brings across `docs/stop_finding.rst` from the abandoned #189, the only prose description of any of this and otherwise lost when that draft is closed. Updated: `_shoot_rays` renamed to `_solve_rays` throughout, a new section on the per-field entrance pupil and its three fallbacks, and a corrected statement of the frame conventions, which are now four rather than one, plus a note that the invariance test is what enforces them.

That last part is the general lesson. Nothing in the type system distinguishes rays in the object frame from rays in a launch surface's frame from rays in the sensor's frame from rays in the world frame, so every one of these bugs is silent and shows up only as a wrong number. The page now says which frame each function takes and returns, and there is now a test which fails when one of them drifts.

## Tests

`pytest optika`: 22315 passed, 304 skipped, 18 xfailed (including the known chart pole, #227).

## Note

#198 also needs rebasing against `main` independently; it is based 25 commits back and conflicts there the same trivial way (two appends at the end of the test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lm9SxSpyNg9hx8dNL9pUXc
