### PR TITLE
Solve the generic sag intercept in the sag's own frame

### DIFF
--- a/optika/_tests/test_mixins.py
+++ b/optika/_tests/test_mixins.py
@@ -12,6 +12,9 @@ import optika
 transformation_parameterization = [
     None,
     na.transformations.Cartesian3dTranslation(x=5 * u.mm),
+    # A translation along z. Every other entry leaves z unchanged, which is
+    # what let a sag intercept solved in the wrong frame go unnoticed.
+    na.transformations.Cartesian3dTranslation(z=7 * u.mm),
     na.transformations.TransformationList(
         [
             na.transformations.Cartesian3dTranslation(x=5 * u.mm),

--- a/optika/sags/_abc.py
+++ b/optika/sags/_abc.py
@@ -89,12 +89,22 @@ class AbstractSag(
             input rays that will intercept this sag function
         """
 
+        # Solve in this sag's own frame, as the closed-form intercepts do.
+        # `self(position)` measures the sag from the local `z = 0` plane, so
+        # comparing it against a `z` in the parent frame would mix the two.
+        transformation = self.transformation
+        if transformation is not None:
+            rays = transformation.inverse(rays)
+            sag = self.replace(transformation=None)
+        else:
+            sag = self
+
         def line(t: na.AbstractScalar) -> na.Cartesian3dVectorArray:
             return rays.position + rays.direction * t
 
         def func(t: na.AbstractScalar) -> na.AbstractScalar:
             a = line(t)
-            z = self(a)
+            z = sag(a)
             return a.z - z
 
         t_intercept = na.optimize.root_secant(
@@ -105,6 +115,10 @@ class AbstractSag(
 
         result = rays.copy_shallow()
         result.position = line(t_intercept)
+
+        if transformation is not None:
+            result = transformation(result)
+
         return result
 
     def propagate_rays(

--- a/optika/sags/_tests/_abc_test.py
+++ b/optika/sags/_tests/_abc_test.py
@@ -96,7 +96,18 @@ class AbstractTestAbstractSag(
     ):
         result = a.intercept(rays)
 
-        assert np.allclose(a(result.position), result.position.z)
+        # The intercept has to lie on the surface, and the surface is defined
+        # in the sag's own frame, where `z` equals the sag. Compare there:
+        # `__call__` measures the sag from the local `z = 0` plane for most
+        # sags but returns a parent-frame `z` for `NoSag`, and the two agree
+        # once the transformation is taken off.
+        sag = a.replace(transformation=None)
+
+        position = result.position
+        if a.transformation is not None:
+            position = a.transformation.inverse(position)
+
+        assert np.allclose(sag(position), position.z)
 
         result_expected = optika.sags.AbstractSag.intercept(a, rays)
 


### PR DESCRIPTION
## The bug

`AbstractSag.intercept` solved its root equation across two frames. The residual is `a.z - self(a)`, where `a.z` is a depth in the parent frame but `self(a)` measures the sag from the sag's own `z = 0` plane. Any `transformation` with a component along z cancelled out of the equation and was silently ignored.

A sphere translated 10 mm along z shows it directly:

```python
sag = optika.sags.SphericalSag(
    radius=500 * u.mm,
    transformation=na.transformations.Cartesian3dTranslation(z=10 * u.mm),
)
```

| path | intercept z |
| --- | --- |
| `sag.intercept(rays)`, closed form | 10.125 mm |
| `AbstractSag.intercept(sag, rays)`, generic solver | 0.125 mm |

The second is byte-identical to the same sag with no transformation at all.

Most sags hide this behind a closed-form `intercept` of their own, which already transforms the rays in and the result back out. The two that do not are `ToroidalSag`, and `ZernikeSag` in #172 — whose own third test instance carries a `Cartesian3dTranslation(z=10 * u.mm)` that, until now, meant nothing.

## The fix

Solve in the sag's frame, exactly as the closed-form intercepts already do: inverse-transform the rays, solve against a copy of the sag with the transformation taken off, and carry the result back out. A translated toroid now lands at 10.0875 mm where the untranslated one lands at 0.0875 mm, and the generic solver agrees with every closed form to the last bit.

## Why the suite did not catch it

`transformation_parameterization` held only translations along x and rotations about z. Every one of those leaves z unchanged, which is exactly the invariance under which a depth measured in the wrong frame is indistinguishable from one measured in the right frame. It is the same blind spot #222 describes at the system level, where every fixture placed its surfaces with translations alone.

Adding a single translation along z makes the existing assertions discriminate. Reverting this fix now fails **234 tests across all five sag types**:

| test class | failures |
| --- | --- |
| `TestToroidalSag::test_intercept` | 108 |
| `TestConicSag::test_intercept` | 72 |
| `TestSphericalSag::test_intercept` | 18 |
| `TestParabolicSag::test_intercept` | 18 |
| `TestCylindricalSag::test_intercept` | 18 |

`test_intercept` also asserted that the sag at the intercept equals the intercept's own z, comparing a parent-frame z against a sag measured in the local frame. It passed only because no fixture moved z. It now compares in the sag's own frame.

## Scope

**No design changes.** No sag in `optika` or `esis` is constructed with its own `transformation`, so every existing raytrace produces the same numbers. This fixes the path a transformed sag would have taken. Full suite: 24033 passed, 0 failed.

## Related, and deliberately not changed here

`NoSag.__call__` returns a parent-frame z where the other six sags return a local depth. Called at the origin with the same 10 mm translation:

| sag | value |
| --- | --- |
| `NoSag` | 10 mm |
| `SphericalSag` | 0 mm |
| `ParabolicSag` | 0 mm |

The generic intercept was written against `NoSag`'s convention, which is how it came to disagree with everything else. #222 documents the system-level call sites as expecting a local depth, so `NoSag` looks like the outlier — but settling that is a separate change with its own blast radius. The assertion added here is written to hold under either convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
